### PR TITLE
feat: add support for Deno.upgradeWebSocket

### DIFF
--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -7,6 +7,8 @@ export class DrashResponse {
   public headers: Headers = new Headers();
   public status = 200;
   public statusText = "OK";
+  public upgraded = false;
+  public upgraded_response: Response|null = null;
 
   //////////////////////////////////////////////////////////////////////////////
   // FILE MARKER - PUBLIC METHODS //////////////////////////////////////////////
@@ -162,5 +164,16 @@ export class DrashResponse {
   public text(text: string) {
     this.body = text;
     this.headers.set("Content-Type", "text/plain");
+  }
+
+  /**
+   * Upgrade the response.
+   *
+   * @param response - The upgraded response (e.g. a WebSocket connection
+   * response via Deno.upgradeWebSocket()).
+   */
+  public upgrade(response: Response): void {
+    this.upgraded = true;
+    this.upgraded_response = response;
   }
 }

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -8,7 +8,7 @@ export class DrashResponse {
   public status = 200;
   public statusText = "OK";
   public upgraded = false;
-  public upgraded_response: Response|null = null;
+  public upgraded_response: Response | null = null;
 
   //////////////////////////////////////////////////////////////////////////////
   // FILE MARKER - PUBLIC METHODS //////////////////////////////////////////////

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -170,7 +170,7 @@ export class Server {
   #getHandler(): (r: Request) => Promise<Response> {
     const resources = this.#resources;
     const serverServices = this.#options.services ?? [];
-    return async function (originalRequest: Request) {
+    return async function (originalRequest: Request): Promise<Response> {
       try {
         // If a service wants to respond early, then allow it but dont run the resource method and still
         // allow services to run eg csrf, paladin
@@ -308,6 +308,10 @@ export class Server {
 
         if (serviceError) {
           throw serviceError;
+        }
+
+        if (response.upgraded && response.upgraded_response) {
+          return response.upgraded_response;
         }
 
         return new Response(response.body, {

--- a/tests/integration/upgrade_websocket_test.ts
+++ b/tests/integration/upgrade_websocket_test.ts
@@ -1,4 +1,4 @@
-import { Rhum, TestHelpers } from "../deps.ts";
+import { Rhum } from "../deps.ts";
 import { Request, Resource, Response, Server } from "../../mod.ts";
 
 const messages: MessageEvent[] = [];
@@ -46,7 +46,7 @@ Deno.test("integration/upgrade_websocket_test.ts", async () => {
 
   const socket = new WebSocket("ws://localhost:3000");
 
-  const p = new Promise((resolve, reject) => {
+  const p = new Promise((resolve, _reject) => {
     // We pass the `resolve` function to the `r` variable so that the
     // `socket.onmessage()` call in the `GET()` method in the resource can use
     // it to resolve. This makes the `Promise` truly wait until the `messages`

--- a/tests/integration/upgrade_websocket_test.ts
+++ b/tests/integration/upgrade_websocket_test.ts
@@ -17,12 +17,7 @@ class HomeResource extends Resource {
       response: upgradedResponse,
     } = Deno.upgradeWebSocket(request);
 
-    socket.onopen = () => {
-      console.log("server connected");
-    };
-
     socket.onmessage = (message) => {
-      console.log(`message`, message.data);
       messages.push(message.data);
       if (globalResolve) {
         globalResolve(messages);

--- a/tests/integration/upgrade_websocket_test.ts
+++ b/tests/integration/upgrade_websocket_test.ts
@@ -63,5 +63,4 @@ Deno.test("integration/upgrade_websocket_test.ts", async () => {
     "this is a message from the client",
   );
   await server.close();
-
 });

--- a/tests/integration/upgrade_websocket_test.ts
+++ b/tests/integration/upgrade_websocket_test.ts
@@ -54,6 +54,7 @@ Deno.test("integration/upgrade_websocket_test.ts", async () => {
     globalResolve = resolve;
     socket.onopen = () => {
       socket.send("this is a message from the client");
+      // Close the connection so that this test doesn't leak async ops
       socket.close();
     };
   });

--- a/tests/integration/upgrade_websocket_test.ts
+++ b/tests/integration/upgrade_websocket_test.ts
@@ -1,0 +1,73 @@
+import { Rhum, TestHelpers } from "../deps.ts";
+import { Request, Resource, Response, Server } from "../../mod.ts";
+
+const messages: MessageEvent[] = [];
+let globalResolve: ((arg: unknown) => void) | null = null;
+
+////////////////////////////////////////////////////////////////////////////////
+// FILE MARKER - APP SETUP /////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+class HomeResource extends Resource {
+  paths = ["/"];
+
+  public GET(request: Request, response: Response) {
+    const {
+      socket,
+      response: upgradedResponse,
+    } = Deno.upgradeWebSocket(request);
+
+    socket.onopen = () => {
+      console.log("server connected");
+    };
+
+    socket.onmessage = (message) => {
+      console.log(`message`, message.data);
+      messages.push(message.data);
+      if (globalResolve) {
+        globalResolve(messages);
+      }
+    };
+
+    return response.upgrade(upgradedResponse);
+  }
+}
+
+const server = new Server({
+  resources: [
+    HomeResource,
+  ],
+  protocol: "http",
+  hostname: "localhost",
+  port: 3000,
+});
+
+////////////////////////////////////////////////////////////////////////////////
+// FILE MARKER - TESTS /////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+Deno.test("integration/upgrade_websocket_test.ts", async () => {
+  server.run();
+
+  const socket = new WebSocket("ws://localhost:3000");
+
+  const p = new Promise((resolve, reject) => {
+    // We pass the `resolve` function to the `r` variable so that the
+    // `socket.onmessage()` call in the `GET()` method in the resource can use
+    // it to resolve. This makes the `Promise` truly wait until the `messages`
+    // array has the message that was sent from the client.
+    globalResolve = resolve;
+    socket.onopen = () => {
+      socket.send("this is a message from the client");
+    };
+  });
+
+  p.then((messages) => {
+    Rhum.asserts.assertEquals(
+      (messages as MessageEvent[])[0],
+      "this is a message from the client",
+    );
+  });
+
+  await server.close();
+});


### PR DESCRIPTION
POC for `Deno.upgradeWebSocket` usage. For some reason, we can't do this:

```typescript
const { socket, response: res } = Deno.upgradeWebSocket(request);
response.headers = res.headers;
response.status = res.status;
response.statusText = res.statusText;

return response.text("WebSocket connected.");
```

 That's why I added the `.upgrade()` method on the `Response`.

Example app:

`import { Drash } from "./deps.ts";` should reference the `mod.ts` in THIS branch.

```typescript
import { Drash } from "./deps.ts";

////////////////////////////////////////////////////////////////////////////////
// FILE MARKER - RESOURCES /////////////////////////////////////////////////////
////////////////////////////////////////////////////////////////////////////////

class HomeResource extends Drash.Resource {
  public paths = [
    "/",
  ];

  public GET(
    request: Drash.Request,
    response: Drash.Response,
  ): void | Response {
    try {
      const { socket, response: res } = Deno.upgradeWebSocket(request);

      socket.onmessage = (message) => {
        console.log("Hey we received something!");
      }

      return response.upgrade(res);
    } catch (error) {
      console.log(error);
    }
  }
}

////////////////////////////////////////////////////////////////////////////////
// FILE MARKER - SERVER INSTANTIATION //////////////////////////////////////////
////////////////////////////////////////////////////////////////////////////////

const server = new Drash
  .Server(
  {
    hostname: "0.0.0.0",
    port: 1447,
    protocol: "http",
    resources: [
      HomeResource,
    ],
  },
);

server.run();

console.log(`Server running at ${server.address}.`);
```

**Tasks**

- [x] Documentation