### PR TITLE
fix: request content-length and content-type checks

### DIFF
--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -147,8 +147,8 @@ export class DrashRequest extends Request {
    * @returns A parsed body based on the content type of the request body.
    */
   async #parseBody(): Promise<ParsedBody> {
-    const contentLength = this.headers.get("Content-Length")
-      ?? this.headers.get("content-length");
+    const contentLength = this.headers.get("Content-Length") ??
+      this.headers.get("content-length");
 
     // The Content-Length header indicates that the client is sending a body.
     // Some clients send a Content-Length header of "0", which indicates that
@@ -163,13 +163,13 @@ export class DrashRequest extends Request {
     // body, we need to know the Content-Type of the body. Otherwise, we have
     // no way of knowing how to parse it. We can assume, but let's just tell the
     // client to modify their request to include the Content-Type header.
-    const contentType = this.headers.get("Content-Type")
-      ?? this.headers.get("content-type");
+    const contentType = this.headers.get("Content-Type") ??
+      this.headers.get("content-type");
 
     if (!contentType) {
       throw new Errors.HttpError(
         400,
-        "Bad Request. The request body cannot be parsed due to the Content-Type header missing."
+        "Bad Request. The request body cannot be parsed due to the Content-Type header missing.",
       );
     }
 

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -147,13 +147,33 @@ export class DrashRequest extends Request {
    * @returns A parsed body based on the content type of the request body.
    */
   async #parseBody(): Promise<ParsedBody> {
-    try {
-      const contentType = this.headers.get(
-        "Content-Type",
+    const contentLength = this.headers.get("Content-Length")
+      ?? this.headers.get("content-length");
+
+    // The Content-Length header indicates that the client is sending a body.
+    // Some clients send a Content-Length header of "0", which indicates that
+    // there is in fact no body present with the request. We need to check for
+    // this or else we try to parse a body for no reason.
+    if (!contentLength || contentLength === "0") {
+      return undefined;
+    }
+
+    // If we get to this point, then that means there is a body (since the
+    // Content-Length header is greater than 0). In order for us to parse the
+    // body, we need to know the Content-Type of the body. Otherwise, we have
+    // no way of knowing how to parse it. We can assume, but let's just tell the
+    // client to modify their request to include the Content-Type header.
+    const contentType = this.headers.get("Content-Type")
+      ?? this.headers.get("content-type");
+
+    if (!contentType) {
+      throw new Errors.HttpError(
+        400,
+        "Bad Request. The request body cannot be parsed due to the Content-Type header missing."
       );
-      if (!contentType) {
-        return await this.#constructFormDataUsingBody();
-      }
+    }
+
+    try {
       if (contentType.includes("multipart/form-data")) {
         return await this.#constructFormDataUsingBody();
       }
@@ -166,11 +186,13 @@ export class DrashRequest extends Request {
       if (contentType.includes("text/plain")) {
         return await this.text();
       }
+
+      // If all else fails, then try to parse the body using FormData
       return await this.#constructFormDataUsingBody();
     } catch (_e) {
       throw new Errors.HttpError(
         422,
-        "Unprocessable entity. The request body seems to be invalid as there was an error parsing it",
+        "Unprocessable Entity. The request body seems to be invalid as there was an error parsing it.",
       );
     }
   }

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -147,8 +147,7 @@ export class DrashRequest extends Request {
    * @returns A parsed body based on the content type of the request body.
    */
   async #parseBody(): Promise<ParsedBody> {
-    const contentLength = this.headers.get("Content-Length") ??
-      this.headers.get("content-length");
+    const contentLength = this.headers.get("content-length");
 
     // The Content-Length header indicates that the client is sending a body.
     // Some clients send a Content-Length header of "0", which indicates that
@@ -163,8 +162,7 @@ export class DrashRequest extends Request {
     // body, we need to know the Content-Type of the body. Otherwise, we have
     // no way of knowing how to parse it. We can assume, but let's just tell the
     // client to modify their request to include the Content-Type header.
-    const contentType = this.headers.get("Content-Type") ??
-      this.headers.get("content-type");
+    const contentType = this.headers.get("content-type");
 
     if (!contentType) {
       throw new Errors.HttpError(

--- a/src/services/graphql/graphql.ts
+++ b/src/services/graphql/graphql.ts
@@ -8,6 +8,7 @@ interface GraphQLOptions {
   schema: GraphQL.GraphQLSchema;
   graphiql: GraphiQLValue;
   // TODO(crookse) Figure out how to add typings for the args
+  // deno-lint-ignore no-explicit-any
   rootValue: Record<string, (...args: any) => string>;
 }
 
@@ -58,7 +59,7 @@ export class GraphQLService extends Drash.Service {
    * @param request
    * @param response
    */
-  #handleGetRequests(request: Drash.Request, response: Drash.Response): void {
+  #handleGetRequests(_request: Drash.Request, response: Drash.Response): void {
     const playgroundEndpoint = this.#options.graphiql === true
       ? "/graphql"
       : typeof this.#options.graphiql === "string"

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -12,4 +12,3 @@ export { ServerRequest } from "https://deno.land/std@0.106.0/http/server.ts";
 export type { Response } from "https://deno.land/std@0.106.0/http/server.ts";
 export { green, red } from "https://deno.land/std@0.106.0/fmt/colors.ts";
 export { delay } from "https://deno.land/std@0.113.0/async/delay.ts";
-export { buildSchema } from "https://cdn.skypack.dev/graphql@15.5.0?dts"; // TODO ENSURE DMM UPDATES THIS

--- a/tests/integration/graphql_test.ts
+++ b/tests/integration/graphql_test.ts
@@ -1,5 +1,4 @@
 import { Rhum } from "../deps.ts";
-import { buildSchema } from "../deps.ts";
 import * as Drash from "../../mod.ts";
 import { GraphQL, GraphQLService } from "../../src/services/graphql/graphql.ts";
 

--- a/tests/integration/posting_invalid_json_test.ts
+++ b/tests/integration/posting_invalid_json_test.ts
@@ -51,7 +51,7 @@ Rhum.testPlan("posting_invlaid_json_test.ts", () => {
       await server.close();
       Rhum.asserts.assertEquals(
         (await response.text()).startsWith(
-          "Error: Unprocessable entity. The request body seems to be invalid as there was an error parsing it",
+          "Error: Unprocessable Entity. The request body seems to be invalid as there was an error parsing it.",
         ),
         true,
       );

--- a/tests/test_helpers.ts
+++ b/tests/test_helpers.ts
@@ -89,35 +89,42 @@ export const makeRequest = {
     options = Object.assign(options, {
       method: "GET",
     });
-    options.body = JSON.stringify(options.body);
     return fetch(url, options);
   },
   post(url: string, options: IMakeRequestOptions = {}) {
     options = Object.assign(options, {
       method: "POST",
     });
-    options.body = JSON.stringify(options.body);
+    if (options.body) {
+      options.body = JSON.stringify(options.body);
+    }
     return fetch(url, options);
   },
   put(url: string, options: IMakeRequestOptions = {}) {
     options = Object.assign(options, {
       method: "PUT",
     });
-    options.body = JSON.stringify(options.body);
+    if (options.body) {
+      options.body = JSON.stringify(options.body);
+    }
     return fetch(url, options);
   },
   delete(url: string, options: IMakeRequestOptions = {}) {
     options = Object.assign(options, {
       method: "DELETE",
     });
-    options.body = JSON.stringify(options.body);
+    if (options.body) {
+      options.body = JSON.stringify(options.body);
+    }
     return fetch(url, options);
   },
   patch(url: string, options: IMakeRequestOptions = {}) {
     options = Object.assign(options, {
       method: "PATCH",
     });
-    options.body = JSON.stringify(options.body);
+    if (options.body) {
+      options.body = JSON.stringify(options.body);
+    }
     return fetch(url, options);
   },
 };

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -130,6 +130,13 @@ function bodyTests() {
     formData.append("foo[]", file1, "hello.json");
     formData.append("foo[]", file2, "world.json");
     const serverRequest = new Request("https://drash.land", {
+      headers: {
+        // We use `"Content-Length": "1"` to tell Drash.Request that there is
+        // a request body. This is a hack just for unit testing. In the real
+        // world, the Content-Length header will be defined (at least it
+        // should be) by the client.
+        "Content-Length": "1",
+      },
       body: formData,
       method: "POST",
     });
@@ -138,6 +145,7 @@ function bodyTests() {
       new Map(),
       connInfo,
     );
+
     Rhum.asserts.assertEquals(request.bodyParam("foo"), [
       {
         content: '{\n  "hello": "world"\n}',
@@ -162,6 +170,13 @@ function bodyTests() {
     });
     formData.append("foo", file, "hello.json");
     const serverRequest = new Request("https://drash.land", {
+      headers: {
+        // We use `"Content-Length": "1"` to tell Drash.Request that there is
+        // a request body. This is a hack just for unit testing. In the real
+        // world, the Content-Length header will be defined (at least it
+        // should be) by the client.
+        "Content-Length": "1"
+      },
       body: formData,
       method: "POST",
     });
@@ -184,6 +199,13 @@ function bodyTests() {
       const formData = new FormData();
       formData.append("user", "Drash");
       const req = new Request("https://drash.land", {
+        headers: {
+          // We use `"Content-Length": "1"` to tell Drash.Request that there is
+          // a request body. This is a hack just for unit testing. In the real
+          // world, the Content-Length header will be defined (at least it
+          // should be) by the client.
+          "Content-Length": "1"
+        },
         body: formData,
         method: "POST",
       });
@@ -203,6 +225,13 @@ function bodyTests() {
     });
     formData.append("foo[]", file, "hello.json");
     const serverRequest = new Request("https://drash.land", {
+      headers: {
+        // We use `"Content-Length": "1"` to tell Drash.Request that there is
+        // a request body. This is a hack just for unit testing. In the real
+        // world, the Content-Length header will be defined (at least it
+        // should be) by the client.
+        "Content-Length": "1",
+      },
       body: formData,
       method: "POST",
     });
@@ -218,6 +247,11 @@ function bodyTests() {
     async () => {
       const req = new Request("https://drash.land", {
         headers: {
+          // We use `"Content-Length": "1"` to tell Drash.Request that there is
+          // a request body. This is a hack just for unit testing. In the real
+          // world, the Content-Length header will be defined (at least it
+          // should be) by the client.
+          "Content-Length": "1",
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
@@ -239,6 +273,11 @@ function bodyTests() {
     async () => {
       const serverRequest = new Request("https://drash.land", {
         headers: {
+          // We use `"Content-Length": "1"` to tell Drash.Request that there is
+          // a request body. This is a hack just for unit testing. In the real
+          // world, the Content-Length header will be defined (at least it
+          // should be) by the client.
+          "Content-Length": "1",
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
@@ -266,6 +305,13 @@ function bodyTests() {
       formData.append("foo", file, "hello.json");
       formData.append("user", "drash");
       const serverRequest = new Request("https://drash.land", {
+        headers: {
+          // We use `"Content-Length": "1"` to tell Drash.Request that there is
+          // a request body. This is a hack just for unit testing. In the real
+          // world, the Content-Length header will be defined (at least it
+          // should be) by the client.
+          "Content-Length": "1",
+        },
         body: formData,
         method: "POST",
       });
@@ -288,6 +334,11 @@ function bodyTests() {
   Rhum.testCase("Can handle when a body param is an object", async () => {
     const serverRequest = new Request("https://drash.land", {
       headers: {
+        // We use `"Content-Length": "1"` to tell Drash.Request that there is
+        // a request body. This is a hack just for unit testing. In the real
+        // world, the Content-Length header will be defined (at least it
+        // should be) by the client.
+        "Content-Length": "1",
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
@@ -317,6 +368,11 @@ function bodyTests() {
   Rhum.testCase("Can handle when a body param is an array", async () => {
     const serverRequest = new Request("https://drash.land", {
       headers: {
+        // We use `"Content-Length": "1"` to tell Drash.Request that there is
+        // a request body. This is a hack just for unit testing. In the real
+        // world, the Content-Length header will be defined (at least it
+        // should be) by the client.
+        "Content-Length": "1",
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
@@ -340,6 +396,11 @@ function bodyTests() {
   Rhum.testCase("Can handle when a body param is a boolean", async () => {
     const serverRequest = new Request("https://drash.land", {
       headers: {
+        // We use `"Content-Length": "1"` to tell Drash.Request that there is
+        // a request body. This is a hack just for unit testing. In the real
+        // world, the Content-Length header will be defined (at least it
+        // should be) by the client.
+        "Content-Length": "1",
         "Content-Type": "application/json",
       },
       body: JSON.stringify({

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -175,7 +175,7 @@ function bodyTests() {
         // a request body. This is a hack just for unit testing. In the real
         // world, the Content-Length header will be defined (at least it
         // should be) by the client.
-        "Content-Length": "1"
+        "Content-Length": "1",
       },
       body: formData,
       method: "POST",
@@ -204,7 +204,7 @@ function bodyTests() {
           // a request body. This is a hack just for unit testing. In the real
           // world, the Content-Length header will be defined (at least it
           // should be) by the client.
-          "Content-Length": "1"
+          "Content-Length": "1",
         },
         body: formData,
         method: "POST",


### PR DESCRIPTION
* Add check for `Content-Length` header
  * If `Content-Length` is null, then there is no body, so return `undefined` for the `#parsed_body`
  * If `Content-Length` is 0, then there is no body, so return `undefined` for the `#parsed_body`
* Add check for `Content-Type` header
  * If `Content-Length` is greater than 0, then there is a body and we must rely on the `Content-Type` header to parse the body correctly. If it is not present, then we throw a `400 Bad Request` error response.
* Fixed `request_test.ts` tests to include `Content-Length` so that they don't error out. The approach is hacky, but is only used in tests. In the real world, the `Content-Length` header should be provided by the client making the request.