### PR TITLE
chore(service/rate_limiter): split classes into separate files; use s…

### DIFF
--- a/src/services/rate_limiter/memory_store.ts
+++ b/src/services/rate_limiter/memory_store.ts
@@ -1,0 +1,84 @@
+export class MemoryStore {
+  #hits: Record<string, number> = {};
+  #interval_id: number | null = null;
+  #reset_time: Date;
+  #timeframe: number;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // FILE MARKER - CONSTRUCTOR /////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @param timeframe - Reset time/duration
+   */
+  constructor(timeframe: number) {
+    this.#reset_time = this.#calculateNextResetTime(timeframe);
+    this.#timeframe = timeframe;
+    this.#queueReset();
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // FILE MARKER - PUBLIC METHODS //////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * Mainly used in tests, to cleanup ops
+   */
+  public cleanup() {
+    if (this.#interval_id) {
+      clearInterval(this.#interval_id);
+    }
+  }
+
+  /**
+   * Increase the number of hits given the ip
+   *
+   * @param key - The IP of the request
+   *
+   * @returns The current amount of requests recieved for `key` (`hits`) and
+   * the reset time
+   */
+  public increment(key: string): {
+    current: number;
+    reset_time: Date;
+  } {
+    if (this.#hits[key]) {
+      this.#hits[key]++;
+    } else {
+      this.#hits[key] = 1;
+    }
+
+    return {
+      current: this.#hits[key],
+      reset_time: this.#reset_time,
+    };
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // FILE MARKER - PRIVATE METHODS /////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * Create the next reset time given the timeframe.
+   *
+   * @param timeframe - Essentially, current time + timeframe.
+   *
+   * @returns The new reset time.
+   */
+  #calculateNextResetTime(timeframe: number): Date {
+    const d = new Date();
+    d.setMilliseconds(d.getMilliseconds() + timeframe);
+    return d;
+  }
+
+  /**
+   * Start an interval to reset the hits and reset time based on the timeframe.
+   */
+  #queueReset() {
+    this.#interval_id= setInterval(() => {
+      this.#hits = {};
+      this.#reset_time = this.#calculateNextResetTime(this.#timeframe);
+    }, this.#timeframe);
+  }
+}
+

--- a/src/services/rate_limiter/memory_store.ts
+++ b/src/services/rate_limiter/memory_store.ts
@@ -35,7 +35,7 @@ export class MemoryStore {
    *
    * @param key - The IP of the request
    *
-   * @returns The current amount of requests recieved for `key` (`hits`) and
+   * @returns The current amount of requests received for `key` (`hits`) and
    * the reset time
    */
   public increment(key: string): {

--- a/src/services/rate_limiter/memory_store.ts
+++ b/src/services/rate_limiter/memory_store.ts
@@ -75,10 +75,9 @@ export class MemoryStore {
    * Start an interval to reset the hits and reset time based on the timeframe.
    */
   #queueReset() {
-    this.#interval_id= setInterval(() => {
+    this.#interval_id = setInterval(() => {
       this.#hits = {};
       this.#reset_time = this.#calculateNextResetTime(this.#timeframe);
     }, this.#timeframe);
   }
 }
-

--- a/src/services/rate_limiter/rate_limiter.ts
+++ b/src/services/rate_limiter/rate_limiter.ts
@@ -38,7 +38,9 @@ export class RateLimiterService extends Service {
 
   public runBeforeResource(request: Request, response: Response): void {
     const key = (request.conn_info.remoteAddr as Deno.NetAddr).hostname;
-    const { current, reset_time: resetTime } = this.#memory_store.increment(key);
+    const { current, reset_time: resetTime } = this.#memory_store.increment(
+      key,
+    );
     const requestsRemaining = Math.max(this.#options.max_requests - current, 0);
 
     response.headers.set(

--- a/src/services/rate_limiter/rate_limiter.ts
+++ b/src/services/rate_limiter/rate_limiter.ts
@@ -1,4 +1,4 @@
-import { Errors, IService, Request, Response, Service } from "../../../mod.ts";
+import { Errors, Request, Response, Service } from "../../../mod.ts";
 import { MemoryStore } from "./memory_store.ts";
 
 interface IOptions {
@@ -10,6 +10,7 @@ interface IOptions {
   /**
    * Number of requests an IP is allowed within the `timeframe`.
    */
+  // deno-lint-ignore camelcase
   max_requests: number;
 }
 

--- a/src/services/rate_limiter/rate_limiter.ts
+++ b/src/services/rate_limiter/rate_limiter.ts
@@ -61,13 +61,15 @@ export class RateLimiterService extends Service {
     );
 
     if (this.#options.max_requests && current > this.#options.max_requests) {
+      const retryAfter = Math.ceil(this.#options.timeframe / 1000).toString() +
+        "s";
       response.headers.set(
         "X-Retry-After",
-        Math.ceil(this.#options.timeframe / 1000).toString() + "s",
+        retryAfter,
       );
       throw new Errors.HttpError(
         429,
-        "Too many requests, please try again later.",
+        `Too Many Requests. Please try again after ${retryAfter}.`,
       );
     }
   }

--- a/tests/integration/rate_limiter_test.ts
+++ b/tests/integration/rate_limiter_test.ts
@@ -86,8 +86,11 @@ Rhum.testPlan("rate_limiter_test", () => {
         await server.close();
         Rhum.asserts.assertEquals(res4.status, 429);
         const text = await res4.text();
+        const retryAfter = res4.headers.get("x-retry-after");
         Rhum.asserts.assert(
-          text.startsWith("Error: Too many requests, please try again later."),
+          text.startsWith(
+            "Error: Too Many Requests. Please try again after " + retryAfter,
+          ),
         );
         Rhum.asserts.assert(res4.headers.get("date"));
         Rhum.asserts.assertEquals(res4.headers.get("x-ratelimit-limit"), "3");

--- a/tests/integration/rate_limiter_test.ts
+++ b/tests/integration/rate_limiter_test.ts
@@ -16,7 +16,7 @@ Rhum.testPlan("rate_limiter_test", () => {
       async () => {
         const rateLimiter = new RateLimiterService({
           timeframe: 15 * 60 * 1000,
-          maxRequests: 3,
+          max_requests: 3,
         });
         const server = new Drash.Server({
           resources: [Resource],
@@ -57,7 +57,7 @@ Rhum.testPlan("rate_limiter_test", () => {
       async () => {
         const rateLimiter = new RateLimiterService({
           timeframe: 15 * 60 * 1000,
-          maxRequests: 3,
+          max_requests: 3,
         });
         const server = new Drash.Server({
           resources: [Resource],


### PR DESCRIPTION
* Using snake case for properties
* Put MemoryStore into separate file and imported in into RateLimiterService
* Fixed typos
* Add file markers
* Organized code into public / private sections
* Use `#` instead of `private` access modifier

Tests are failing because of that content-length checking stuff which is addressed in #572 