### PR TITLE
refactor: tengine

### DIFF
--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -130,7 +130,7 @@ export class DrashResponse {
    *
    *   https://github.com/drashland/deno-drash-middleware/tree/master/tengine
    */
-  public render(filepath: string, data: unknown): boolean | string {
+  public render(_filepath: string, _data: unknown): boolean | string {
     return false;
   }
 

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -130,9 +130,7 @@ export class DrashResponse {
    *
    *   https://github.com/drashland/deno-drash-middleware/tree/master/tengine
    */
-  public render(
-    ..._args: unknown[]
-  ): Promise<boolean | string> | boolean | string {
+  public render(filepath: string, data: unknown): boolean | string {
     return false;
   }
 

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -325,6 +325,9 @@ export class Server {
           status: response.status,
         });
       } catch (e) {
+        if (isNaN(e.code)) {
+          e.code = 500;
+        }
         return new Response(e.stack, {
           status: e.code,
           headers: response.headers,

--- a/src/services/tengine/tengine.ts
+++ b/src/services/tengine/tengine.ts
@@ -1,7 +1,8 @@
-import { IService, Request, Response, Service } from "../../../mod.ts";
+import { Request, Response, Service } from "../../../mod.ts";
 import { Jae } from "./jae.ts";
 
 interface IOptions {
+  // deno-lint-ignore camelcase
   views_path: string;
 }
 

--- a/src/services/tengine/tengine.ts
+++ b/src/services/tengine/tengine.ts
@@ -2,40 +2,23 @@ import { IService, Request, Response, Service } from "../../../mod.ts";
 import { Jae } from "./jae.ts";
 
 interface IOptions {
-  render:
-    ((...args: unknown[]) => Promise<boolean | string> | boolean | string);
-  // deno-lint-ignore camelcase
-  views_path?: string;
+  views_path: string;
 }
 
-export class TengineService extends Service implements IService {
+export class TengineService extends Service {
   readonly #options: IOptions;
-
-  #templateEngine: Jae | null = null;
+  #template_engine: Jae;
 
   constructor(options: IOptions) {
     super();
     this.#options = options;
+    this.#template_engine = new Jae(this.#options.views_path);
   }
 
   runBeforeResource(_request: Request, response: Response) {
     response.headers.set("Content-Type", "text/html");
-
-    if (this.#options.views_path) {
-      if (!this.#templateEngine) {
-        this.#templateEngine = new Jae(this.#options.views_path);
-      }
-      this.#options.render = (...args: unknown[]): string => {
-        return this.#templateEngine!.render(
-          args[0] as string,
-          args[1] as unknown,
-        );
-      };
-    }
-
-    if (response.render) {
-      response.render = this.#options.render;
-      return;
-    }
+    response.render = (filepath: string, data: unknown) => {
+      return this.#template_engine.render(filepath, data);
+    };
   }
 }

--- a/tests/integration/tengine_test.ts
+++ b/tests/integration/tengine_test.ts
@@ -12,7 +12,6 @@ import { TengineService } from "../../src/services/tengine/tengine.ts";
 
 const tengine = new TengineService({
   views_path: "./tests/data/views",
-  render: (..._args: unknown[]) => false,
 });
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
i tried getting eta to work and it didn't work. also, they're using deno std 0.97.0. i tried getting dejs to work, but its render method returns a `StringReader` object. i think it's going to take more work to integrate other template engines with tengine and i think the implementation would be wonky af. if users want to use another template engine, then they can write their own service to use the template engine

so now we only support jae. might be worth just merging the jae code into the tengine file. we can save that for later though

docs were updated: https://github.com/drashland/website-v2/pull/40