### PR TITLE
fix(http/error_handler): handle errors gracefully

### DIFF
--- a/src/http/error_handler.ts
+++ b/src/http/error_handler.ts
@@ -34,7 +34,7 @@ export class ErrorHandler implements IErrorHandler {
     // If the error has a code, then we need to make sure it is within the range
     // of HTTP status codes. Otherwise, we cannot convert this to a response.
     if ("code" in error) {
-      const errorWithCode = error as unknown as {code: unknown};
+      const errorWithCode = error as unknown as { code: unknown };
 
       // Start off with 500 as the default
       let code = 500;
@@ -43,8 +43,8 @@ export class ErrorHandler implements IErrorHandler {
       // it is a number AND it is within the range of HTTP status codes, then we
       // replace the default 500 with it.
       if (
-        typeof errorWithCode.code === "number"
-        && STATUS_TEXT.get(errorWithCode.code)
+        typeof errorWithCode.code === "number" &&
+        STATUS_TEXT.get(errorWithCode.code)
       ) {
         code = errorWithCode.code;
       }

--- a/tests/unit/http/error_handler_test.ts
+++ b/tests/unit/http/error_handler_test.ts
@@ -1,0 +1,119 @@
+import * as Drash from "../../../mod.ts";
+import type { ConnInfo } from "../../../deps.ts";
+import { assertEquals } from "../../deps.ts";
+
+const connInfo: ConnInfo = {
+  localAddr: {
+    transport: "tcp",
+    hostname: "localhost",
+    port: 1337,
+  },
+  remoteAddr: {
+    transport: "udp",
+    hostname: "localhost",
+    port: 1337,
+  },
+};
+
+function request() {
+  const req = new Request("https://drash.land", {
+    headers: {
+      Accept: "application/json;text/html",
+    },
+  });
+
+  return new Drash.Request(
+    req,
+    new Map(),
+    connInfo,
+  );
+}
+
+const errorHandler = new Drash.ErrorHandler();
+
+Deno.test("unit/http/error_handler_test.ts | catch() | new Error()", () => {
+  const res = new Drash.Response();
+  errorHandler.catch(
+    new Error(),
+    request(),
+    res,
+  );
+  assertEquals(res.status, 500);
+});
+
+Deno.test("unit/http/error_handler_test.ts | catch() | Built-in JS Errors", () => {
+  const errors = [
+    new EvalError(),
+    new RangeError(),
+    new ReferenceError(),
+    new SyntaxError(),
+    new TypeError(),
+    new URIError(),
+  ];
+
+  errors.forEach((error: Error) => {
+    const res = new Drash.Response();
+    errorHandler.catch(
+      error,
+      request(),
+      res,
+    );
+    assertEquals(res.status, 500);
+  });
+});
+
+Deno.test("unit/http/error_handler_test.ts | catch() | { code: 'Hello' }", () => {
+  const res = new Drash.Response();
+  errorHandler.catch(
+    new ErrorWithRandomCodeString("Hello"),
+    request(),
+    res,
+  );
+  assertEquals(res.status, 500);
+});
+
+Deno.test("unit/http/error_handler_test.ts | catch() | { code: '500' }", () => {
+  const res = new Drash.Response();
+  errorHandler.catch(
+    new ErrorWithRandomCodeString("SQL15023"),
+    request(),
+    res,
+  );
+  assertEquals(res.status, 500);
+});
+
+Deno.test("unit/http/error_handler_test.ts | catch() | { code: 400 }", () => {
+  const res = new Drash.Response();
+  errorHandler.catch(
+    new ErrorWithRandomCodeNumber(400),
+    request(),
+    res,
+  );
+  assertEquals(res.status, 400);
+});
+
+Deno.test("unit/http/error_handler_test.ts | catch() | new Drash.Errors.HttpError(401)", () => {
+  const res = new Drash.Response();
+  errorHandler.catch(
+    new Drash.Errors.HttpError(401),
+    request(),
+    res,
+  );
+  assertEquals(res.status, 401);
+});
+
+class ErrorWithRandomCodeNumber extends Error {
+  public code: number;
+  constructor(code: number, message?: string) {
+    super(message ?? "(no error message provided)");
+    this.code = code;
+  }
+}
+
+class ErrorWithRandomCodeString extends Error {
+  public code: string;
+  constructor(code: string, message?: string) {
+    super(message ?? "(no error message provided)");
+    this.code = code;
+  }
+}


### PR DESCRIPTION
Closes #595 

## Summary

Make sure we default to an HTTP status code of 500 in the event the error object being handled does not contain an HTTP status code that is within the range of HTTP status codes