### PR TITLE
fix: hardcoded redirection http status

### DIFF
--- a/src/http/resource.ts
+++ b/src/http/resource.ts
@@ -34,7 +34,7 @@ export class Resource implements Drash.Interfaces.IResource {
   public redirect(
     location: string,
     response: Drash.Response,
-    status: number = 302,
+    status = 302,
     headers: Drash.Types.HttpHeadersKeyValuePairs = {},
   ): void {
     response.headers.set("Location", location);

--- a/src/http/resource.ts
+++ b/src/http/resource.ts
@@ -20,6 +20,7 @@ export class Resource implements Drash.Interfaces.IResource {
    * ```js
    * this.redirect("http://localhost/login", response);
    * this.redirect("http://localhost/login", response, 301);
+   * this.redirect("http://localhost/login", response, 301, {"some-header": "some value"});
    * ```
    *
    * @param location - The location or resource uri of where you want to

--- a/src/http/resource.ts
+++ b/src/http/resource.ts
@@ -12,8 +12,7 @@ export class Resource implements Drash.Interfaces.IResource {
   public services: Drash.Interfaces.IResourceServices = {};
   public paths: string[] = [];
 
-  // TODO(crookse) Deprecate this method and introduce `response.redirect()` so
-  // it can leverage `this.#setHeaders()`.
+  // TODO(crookse) Deprecate this method and introduce `response.redirect()`
   /**
    * Redirect the incoming request to another resource
    *

--- a/src/http/resource.ts
+++ b/src/http/resource.ts
@@ -12,20 +12,34 @@ export class Resource implements Drash.Interfaces.IResource {
   public services: Drash.Interfaces.IResourceServices = {};
   public paths: string[] = [];
 
+  // TODO(crookse) Deprecate this method and introduce `response.redirect()` so
+  // it can leverage `this.#setHeaders()`.
   /**
    * Redirect the incoming request to another resource
    *
    * @example
    * ```js
    * this.redirect("http://localhost/login", response);
-   * return;
+   * this.redirect("http://localhost/login", response, 301);
    * ```
    *
-   * @param location - The location or resource uri of where you want to redirect the request to
-   * @param response - The response object, to set the related headers and status code on
+   * @param location - The location or resource uri of where you want to
+   * redirect the request to
+   * @param response - The response object, to set the related headers and
+   * status code on
+   * @param status - (optional) The response status. Defaults to 302.
+   * @param headers - (optional) Any extra headers to specify with the response.
    */
-  public redirect(location: string, response: Drash.Response): void {
+  public redirect(
+    location: string,
+    response: Drash.Response,
+    status: Drash.Types.HttpStatusRedirection = 302,
+    headers: Drash.Types.HttpHeadersKeyValuePairs = {},
+  ): void {
     response.headers.set("Location", location);
-    response.status = 302;
+    response.status = status;
+    Object.keys(headers).forEach((key) => {
+      response.headers.set(key, headers[key]);
+    });
   }
 }

--- a/src/http/resource.ts
+++ b/src/http/resource.ts
@@ -29,11 +29,12 @@ export class Resource implements Drash.Interfaces.IResource {
    * status code on
    * @param status - (optional) The response status. Defaults to 302.
    * @param headers - (optional) Any extra headers to specify with the response.
+   * Defaults to an empty object.
    */
   public redirect(
     location: string,
     response: Drash.Response,
-    status: Drash.Types.HttpStatusRedirection = 302,
+    status: number = 302,
     headers: Drash.Types.HttpHeadersKeyValuePairs = {},
   ): void {
     response.headers.set("Location", location);

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,3 +18,20 @@ export type BodyFile = {
   type: string;
   filename: string;
 };
+
+/**
+ * See the following for redirection HTTP status codes:
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages
+ */
+export type HttpStatusRedirection =
+  | 300
+  | 301
+  | 302
+  | 303
+  | 304
+  | 305
+  | 307
+  | 308;
+
+export type HttpHeadersKeyValuePairs = Record<string, string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,19 +19,4 @@ export type BodyFile = {
   filename: string;
 };
 
-/**
- * See the following for redirection HTTP status codes:
- *
- * https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages
- */
-export type HttpStatusRedirection =
-  | 300
-  | 301
-  | 302
-  | 303
-  | 304
-  | 305
-  | 307
-  | 308;
-
 export type HttpHeadersKeyValuePairs = Record<string, string>;

--- a/tests/integration/redirect_test.ts
+++ b/tests/integration/redirect_test.ts
@@ -62,14 +62,19 @@ Rhum.testPlan("redirect_test.ts", () => {
       Rhum.asserts.assertEquals(await response.text(), "hello");
       Rhum.asserts.assertEquals(response.status, 200);
     });
-    Rhum.testCase("Should redirect to another resource with the specified status code", async () => {
-      server.run();
-      // Example browser request
-      const response = await fetch(server.address + "/redirects-with-307", { redirect: "manual" });
-      await server.close();
-      Rhum.asserts.assertEquals(await response.text(), "");
-      Rhum.asserts.assertEquals(response.status, 307);
-    });
+    Rhum.testCase(
+      "Should redirect to another resource with the specified status code",
+      async () => {
+        server.run();
+        // Example browser request
+        const response = await fetch(server.address + "/redirects-with-307", {
+          redirect: "manual",
+        });
+        await server.close();
+        Rhum.asserts.assertEquals(await response.text(), "");
+        Rhum.asserts.assertEquals(response.status, 307);
+      },
+    );
   });
 });
 

--- a/tests/integration/redirect_test.ts
+++ b/tests/integration/redirect_test.ts
@@ -63,7 +63,7 @@ Rhum.testPlan("redirect_test.ts", () => {
       Rhum.asserts.assertEquals(response.status, 200);
     });
     Rhum.testCase(
-      "Should redirect to another resource with the specified status code",
+      "Should respect the status code during redirection",
       async () => {
         server.run();
         // Example browser request

--- a/tests/integration/redirect_test.ts
+++ b/tests/integration/redirect_test.ts
@@ -13,11 +13,19 @@ import { Request, Resource, Response, Server } from "../../mod.ts";
 // FILE MARKER - APP SETUP /////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-class Res extends Resource {
+class Res0 extends Resource {
   paths = ["/"];
 
   public GET(_request: Request, response: Response) {
     this.redirect("http://localhost:3000/redirect", response);
+  }
+}
+
+class Res1 extends Resource {
+  paths = ["/redirects-with-307"];
+
+  public GET(_request: Request, response: Response) {
+    this.redirect("http://localhost:3000/redirect", response, 307);
   }
 }
 
@@ -31,7 +39,8 @@ class Res2 extends Resource {
 
 const server = new Server({
   resources: [
-    Res,
+    Res0,
+    Res1,
     Res2,
   ],
   protocol: "http",
@@ -52,6 +61,14 @@ Rhum.testPlan("redirect_test.ts", () => {
       await server.close();
       Rhum.asserts.assertEquals(await response.text(), "hello");
       Rhum.asserts.assertEquals(response.status, 200);
+    });
+    Rhum.testCase("Should redirect to another resource with the specified status code", async () => {
+      server.run();
+      // Example browser request
+      const response = await fetch(server.address + "/redirects-with-307", { redirect: "manual" });
+      await server.close();
+      Rhum.asserts.assertEquals(await response.text(), "");
+      Rhum.asserts.assertEquals(response.status, 307);
     });
   });
 });


### PR DESCRIPTION
Closes #607 

## Summary

* Remove hard-coded 302 in `resource.redirect()` method
* Allow `status` and `headers` to be specified in `resource.redirect()` (just like the response class' methods)
  * `status` can only be of type `HttpStatusRedirection` which ranges from 300 - 308 (excluding 306 since it's not a used status)

## Other Notes

* We should deprecate the `resource.redirect()` method in favor of `response.redirect()` since `response.redirect()` is the native way to do it based on MDN docs. I didn't know `response.redirect()` existed, so my bad on opting for `resource.redirect()`