### PR TITLE
Fix: Content-Disposition value for download method now used correctly

### DIFF
--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -55,7 +55,7 @@ export class DrashResponse {
   ): void {
     const filepathSplit = filepath.split("/");
     const filename = filepathSplit[filepathSplit.length - 1];
-    this.headers.set("Content-Disposition", `attachment; filename${filename}`);
+    this.headers.set("Content-Disposition", `attachment; filename="${filename}"`);
     this.headers.set("Content-Type", contentType);
     Object.keys(headers).forEach((key) => {
       this.headers.set(key, headers[key]);

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -55,7 +55,10 @@ export class DrashResponse {
   ): void {
     const filepathSplit = filepath.split("/");
     const filename = filepathSplit[filepathSplit.length - 1];
-    this.headers.set("Content-Disposition", `attachment; filename="${filename}"`);
+    this.headers.set(
+      "Content-Disposition",
+      `attachment; filename="${filename}"`,
+    );
     this.headers.set("Content-Type", contentType);
     Object.keys(headers).forEach((key) => {
       this.headers.set(key, headers[key]);

--- a/tests/unit/http/response_test.ts
+++ b/tests/unit/http/response_test.ts
@@ -21,6 +21,20 @@ Deno.test("deleteCookie", () => {
     true,
   );
 });
+Deno.test("download()", () => {
+  const response = new Drash.Response();
+  const filepath = Deno.cwd() + "/tests/data/static_file.txt";
+  response.download(filepath, "text/plain");
+  assertEquals(
+    response.headers.get("Content-Disposition"),
+    `attachment; filename="static_file.txt"`,
+  );
+  assertEquals(response.headers.get("Content-Type"), "text/plain");
+  assertEquals(
+    (new TextDecoder().decode(response.body as Uint8Array)).startsWith("test"),
+    true,
+  );
+});
 Deno.test("text()", () => {
   const response = new Drash.Response();
   response.text("hello", 419, {


### PR DESCRIPTION
Closes #611 

## Summary

According with https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#as_a_response_header_for_the_main_body the value for `Content-Disposition` should contain an equal sign and double quotes for the filename.

![image](https://user-images.githubusercontent.com/7959437/155070467-e2554fa7-14c0-45cd-ab0b-d4244e193dad.png)
