### PR TITLE
feat: Allow services to run at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,13 +9,12 @@ doc_blocks_output_actual.json
 package-lock.json
 
 # directories
-.vim
+.idea
 .sass-cache
+.vim
+node_modules
 tmp*/*
 tmp/*
-node_modules
-.idea
-tmp-dir-for-testing-create-app
 
 # exceptions
 !.gitkeep

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -414,5 +414,5 @@ export class Server {
       statusText: response.statusText,
       status: response.status,
     });
-  };
+  }
 }

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1,44 +1,8 @@
 import * as Drash from "../../mod.ts";
 import { ConnInfo, StdServer } from "../../deps.ts";
 
-interface ResourceAndParams {
-  resource: Drash.Resource;
-  pathParams: Map<string, string>;
-}
-
-type ResourcesAndPatterns = Map<number, {
-  resource: Drash.Resource;
-  patterns: URLPattern[];
-}>;
-
-function getResourceAndParams(
-  url: string,
-  resources: ResourcesAndPatterns,
-): ResourceAndParams | undefined {
-  let resourceAndParams: ResourceAndParams | undefined = undefined;
-  for (const { resource, patterns } of resources.values()) {
-    for (const pattern of patterns) {
-      const result = pattern.exec(url);
-      if (result === null) {
-        continue;
-      }
-      // this is the resource we need, and below are the params
-      const params = new Map();
-      for (const key in result.pathname.groups) {
-        params.set(key, result.pathname.groups[key]);
-      }
-      resourceAndParams = {
-        resource,
-        pathParams: params,
-      };
-      break;
-    }
-  }
-  return resourceAndParams;
-}
-
 async function runServices(
-  Services: Drash.Service[],
+  Services: Drash.Interfaces.IService[],
   request: Drash.Request,
   response: Drash.Response,
   serviceMethod: "runBeforeResource" | "runAfterResource",
@@ -57,10 +21,12 @@ async function runServices(
   // If the service calls `this.end()`, then the request handler we pass in to
   // `new StdServer()` will return `new Response()`.
   for (const Service of Services) {
-    await Service[serviceMethod](request, response);
-    end = Service.send;
-    if (end) {
-      break;
+    if (serviceMethod in Service) {
+      await Service[serviceMethod]!(request, response);
+      end = Service.send;
+      if (end) {
+        break;
+      }
     }
   }
 
@@ -85,7 +51,7 @@ export class Server {
    * a url pattern for every path specified. This means when a request
    * comes in, the paths are already converted to patterns, saving us time
    */
-  readonly #resources: ResourcesAndPatterns = new Map();
+  readonly #resources: Drash.Types.ResourcesAndPatternsMap= new Map();
 
   /**
    * Our server instance that is serving the app
@@ -93,14 +59,26 @@ export class Server {
   #server!: StdServer;
 
   /**
+   * All services that provide extra functionality to the server and the overall
+   * application.
+   */
+  #services: Drash.Interfaces.IService[] = [];
+
+  /**
    * A promise we need to await after calling close() on #server
    */
-  #serverPromise!: Promise<void>;
+  #server_promise!: Promise<void>;
 
   /**
    * A custom Error object handler.
    */
   #error_handler!: Drash.Interfaces.IErrorHandler;
+
+  /**
+   * The error handler to use in the event `this.#error_handler` cannot handle
+   * errors.
+   */
+  #default_error_handler = new Drash.ErrorHandler();
 
   /**
    * The internal and external services used by this server. Internal services
@@ -115,24 +93,12 @@ export class Server {
    * @param options - See the interface for the options' schema.
    */
   constructor(options: Drash.Interfaces.IServerOptions) {
-    if (!options.services) {
-      options.services = [];
-    }
     this.#options = options;
-    this.#options.resources.forEach((resourceClass) => {
-      const resource = new resourceClass();
-      const patterns: URLPattern[] = [];
-      resource.paths.forEach((path) => {
-        // Add "{/}?" to match possible trailing slashes too
-        patterns.push(new URLPattern({ pathname: path + "{/}?" }));
-      });
-      this.#resources.set(this.#resources.size, {
-        resource,
-        patterns,
-      });
-    });
-
     this.#error_handler = new (options.error_handler || Drash.ErrorHandler)();
+
+    // Compile the application
+    this.#addServices();
+    this.#addResources();
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -151,12 +117,31 @@ export class Server {
   //////////////////////////////////////////////////////////////////////////////
 
   /**
+   * Add the given resource to this server's list of resources.
+   *
+   * @param resourceClass - The resource class to instantiate and store in the
+   * resources map.
+   */
+  public addResource(resourceClass: typeof Drash.Resource): void {
+    const resource = new resourceClass();
+    const patterns: URLPattern[] = [];
+    resource.paths.forEach((path: string) => {
+      // Add "{/}?" to match possible trailing slashes too
+      patterns.push(new URLPattern({ pathname: path + "{/}?" }));
+    });
+    this.#resources.set(this.#resources.size, {
+      resource,
+      patterns,
+    });
+  }
+
+  /**
    * Close the server.
    */
   public async close(): Promise<void> {
     try {
       this.#server.close();
-      await this.#serverPromise;
+      await this.#server_promise;
     } catch (_error) {
       // Do nothing. The server was probably already closed.
     }
@@ -169,15 +154,17 @@ export class Server {
     this.#server = new StdServer({
       hostname: this.#options.hostname,
       port: this.#options.port,
-      handler: this.#getHandler(),
+      handler: async (originalRequest: Request, connInfo: ConnInfo) => {
+        return await this.#handleRequest(originalRequest, connInfo);
+      },
     });
 
     if (this.#options.protocol === "http") {
-      this.#serverPromise = this.#server.listenAndServe();
+      this.#server_promise = this.#server.listenAndServe();
     }
 
     if (this.#options.protocol === "https") {
-      this.#serverPromise = this.#server.listenAndServeTls(
+      this.#server_promise = this.#server.listenAndServeTls(
         this.#options.cert_file as string,
         this.#options.key_file as string,
       );
@@ -188,166 +175,244 @@ export class Server {
   // FILE MARKER - PRIVATE METHODS /////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  #getHandler(): (r: Request, connInfo: ConnInfo) => Promise<Response> {
-    const resources = this.#resources;
-    const serverServices = this.#options.services ?? [];
-    const errorHandler = this.#error_handler;
-    const defaultErrorHandler = new Drash.ErrorHandler();
-
-    const respond = (response: Drash.Response): Response => {
-      if (response.upgraded && response.upgraded_response) {
-        return response.upgraded_response;
-      }
-
-      return new Response(response.body, {
-        headers: response.headers,
-        statusText: response.statusText,
-        status: response.status,
-      });
-    };
-
-    return async function (
-      originalRequest: Request,
-      connInfo: ConnInfo,
-    ): Promise<Response> {
-      // Grab resource and path params
-      const resourceAndParams = getResourceAndParams(
-        originalRequest.url,
-        resources,
-      ) ?? {
-        resource: null,
-        pathParams: new Map(),
-      };
-      const { resource, pathParams } = resourceAndParams;
-
-      // Construct request and response objects to pass to services and resource
-      // Keep response top level so we can reuse the headers should an error be thrown
-      // in the try
-      const response = new Drash.Response();
-      try {
-        const request = await Drash.Request.create(
-          originalRequest,
-          pathParams,
-          connInfo,
-        );
-
-        // Run server-level services (before we get to the resource)
-        let endLifecycle = await runServices(
-          serverServices,
-          request,
-          response,
-          "runBeforeResource",
-        );
-
-        if (endLifecycle) {
-          return respond(response);
-        }
-
-        // If no resource found, throw 404. Unable to call class/resource services
-        // when the class doesn't exist!
-        if (!resource) {
-          throw new Drash.Errors.HttpError(404);
-        }
-
-        // Run resource-level services (before their HTTP method is called)
-        endLifecycle = await runServices(
-          resource.services.ALL ?? [],
-          request,
-          response,
-          "runBeforeResource",
-        );
-
-        if (endLifecycle) {
-          return respond(response);
-        }
-
-        // If the method does not exist on the resource, then the method is not
-        // allowed. So, throw that 405 and GTFO. Unable to call resource method
-        // services if the method doesn't exist!
-        const method = request.method
-          .toUpperCase() as Drash.Types.THttpMethod;
-        if (!(method in resource)) {
-          throw new Drash.Errors.HttpError(405);
-        }
-
-        // Run resource HTTP method level services (before the HTTP method is
-        // called)
-        endLifecycle = await runServices(
-          resource.services[method] ?? [],
-          request,
-          response,
-          "runBeforeResource",
-        );
-
-        if (endLifecycle) {
-          return respond(response);
-        }
-
-        // Execute the HTTP method on the resource
-        // Ignoring because we know by now the method exists due to the above check
-        // deno-lint-ignore ban-ts-comment
-        // @ts-ignore
-        await resource[method](request, response);
-
-        // Run resource HTTP method level services (after the HTTP method is
-        // called)
-        endLifecycle = await runServices(
-          resource.services[method] ?? [],
-          request,
-          response,
-          "runAfterResource",
-        );
-
-        if (endLifecycle) {
-          return respond(response);
-        }
-
-        // Run resource-level services (after the HTTP method is called)
-        endLifecycle = await runServices(
-          resource.services.ALL ?? [],
-          request,
-          response,
-          "runAfterResource",
-        );
-
-        if (endLifecycle) {
-          return respond(response);
-        }
-
-        // Run server-level services as a last step before returning a response
-        // that the resource has formed
-        endLifecycle = await runServices(
-          serverServices,
-          request,
-          response,
-          "runAfterResource",
-        );
-
-        if (endLifecycle) {
-          return respond(response);
-        }
-
-        const accept = request.headers.get("accept") ?? "";
-        const contentType = response.headers.get("content-type") ?? "";
-        if (accept.includes("*/*") === false) {
-          if (accept.includes(contentType) === false) {
-            throw new Drash.Errors.HttpError(
-              406,
-              "The requested resource is only capable of returning content that is not acceptable according to the request's Accept headers.",
-            );
-          }
-        }
-
-        return respond(response);
-      } catch (e) {
-        try {
-          await errorHandler.catch(e, originalRequest, response);
-        } catch (e) {
-          await defaultErrorHandler.catch(e, originalRequest, response);
-        }
-
-        return respond(response);
-      }
-    };
+  /**
+   * Add all given resources to this server -- instantiating them so that they
+   * are ready to handle requests at runtime.
+   *
+   * @param resources - Resources defined by the user.
+   */
+  #addResources(): void {
+    this.#options.resources.forEach((resourceClass: typeof Drash.Resource) => {
+      this.addResource(resourceClass);
+    });
   }
+
+  /**
+   * Add all given services in the options.
+   */
+  #addServices(): void {
+    if (this.#options.services) {
+      this.#services = this.#options.services;
+    }
+
+    this.#services.forEach(async (service: Drash.Interfaces.IService) => {
+      if (service.runAtStartup) {
+        await service.runAtStartup({
+          server: this,
+          resources: this.#resources
+        });
+      }
+    });
+  }
+
+  /**
+   * Get the resource associated with the given URL and its path params
+   * associated with it.
+   *
+   * @param url - The URL to match to a resource.
+   * @param resources - The resources map to use to find the resource.
+   */
+  #getResourceAndParams(
+    url: string,
+    resources: Drash.Types.ResourcesAndPatternsMap,
+  ): Drash.Interfaces.IResourceAndParams | undefined {
+    let resourceAndParams: Drash.Interfaces.IResourceAndParams | undefined =
+      undefined;
+
+    for (const { resource, patterns } of resources.values()) {
+      for (const pattern of patterns) {
+        const result = pattern.exec(url);
+
+        // No resource? Check the next one.
+        if (result === null) {
+          continue;
+        }
+
+        // this is the resource we need, and below are the params
+        const params = new Map();
+        for (const key in result.pathname.groups) {
+          params.set(key, result.pathname.groups[key]);
+        }
+
+        resourceAndParams = {
+          resource,
+          pathParams: params,
+        };
+        break;
+      }
+    }
+
+    return resourceAndParams;
+  }
+
+  /**
+   * Handle the given native request. This request gets wrapped around by a
+   * `Drash.Request` object. Reason being we want to make sure methods like
+   * `request.bodyAll()` is available in resources.
+   *
+   * @param originalRequest The native request from Deno's internals.
+   * @param connInfo The connection info from Deno's internals.
+   * @returns A native response.
+   */
+  async #handleRequest(
+    originalRequest: Request,
+    connInfo: ConnInfo,
+  ): Promise<Response> {
+    // Grab resource and path params
+    const resourceAndParams = this.#getResourceAndParams(
+      originalRequest.url,
+      this.#resources,
+    ) ?? {
+      resource: null,
+      pathParams: new Map(),
+    };
+
+    const { resource, pathParams } = resourceAndParams;
+
+    // Construct request and response objects to pass to services and resource
+    // Keep response top level so we can reuse the headers should an error be thrown
+    // in the try
+    const response = new Drash.Response();
+    try {
+      const request = await Drash.Request.create(
+        originalRequest,
+        pathParams,
+        connInfo,
+      );
+
+      // Run server-level services (before we get to the resource)
+      let endLifecycle = await runServices(
+        this.#services,
+        request,
+        response,
+        "runBeforeResource",
+      );
+
+      if (endLifecycle) {
+        return this.#respond(response);
+      }
+
+      // If no resource found, throw 404. Unable to call class/resource services
+      // when the class doesn't exist!
+      if (!resource) {
+        throw new Drash.Errors.HttpError(404);
+      }
+
+      // Run resource-level services (before their HTTP method is called)
+      endLifecycle = await runServices(
+        resource.services.ALL ?? [],
+        request,
+        response,
+        "runBeforeResource",
+      );
+
+      if (endLifecycle) {
+        return this.#respond(response);
+      }
+
+      // If the method does not exist on the resource, then the method is not
+      // allowed. So, throw that 405 and GTFO. Unable to call resource method
+      // services if the method doesn't exist!
+      const method = request.method
+        .toUpperCase() as Drash.Types.HttpMethodName;
+      if (!(method in resource)) {
+        throw new Drash.Errors.HttpError(405);
+      }
+
+      // Run resource HTTP method level services (before the HTTP method is
+      // called)
+      endLifecycle = await runServices(
+        resource.services[method] ?? [],
+        request,
+        response,
+        "runBeforeResource",
+      );
+
+      if (endLifecycle) {
+        return this.#respond(response);
+      }
+
+      // Execute the HTTP method on the resource
+      // Ignoring because we know by now the method exists due to the above check
+      // deno-lint-ignore ban-ts-comment
+      // @ts-ignore
+      await resource[method](request, response);
+
+      // Run resource HTTP method level services (after the HTTP method is
+      // called)
+      endLifecycle = await runServices(
+        resource.services[method] ?? [],
+        request,
+        response,
+        "runAfterResource",
+      );
+
+      if (endLifecycle) {
+        return this.#respond(response);
+      }
+
+      // Run resource-level services (after the HTTP method is called)
+      endLifecycle = await runServices(
+        resource.services.ALL ?? [],
+        request,
+        response,
+        "runAfterResource",
+      );
+
+      if (endLifecycle) {
+        return this.#respond(response);
+      }
+
+      // Run server-level services as a last step before returning a response
+      // that the resource has formed
+      endLifecycle = await runServices(
+        this.#services,
+        request,
+        response,
+        "runAfterResource",
+      );
+
+      if (endLifecycle) {
+        return this.#respond(response);
+      }
+
+      const accept = request.headers.get("accept") ?? "";
+      const contentType = response.headers.get("content-type") ?? "";
+      if (accept.includes("*/*") === false) {
+        if (accept.includes(contentType) === false) {
+          throw new Drash.Errors.HttpError(
+            406,
+            "The requested resource is only capable of returning content that is not acceptable according to the request's Accept headers.",
+          );
+        }
+      }
+
+      return this.#respond(response);
+    } catch (e) {
+      try {
+        await this.#error_handler.catch(e, originalRequest, response);
+      } catch (e) {
+        await this.#default_error_handler.catch(e, originalRequest, response);
+      }
+
+      return this.#respond(response);
+    }
+  }
+
+  /**
+   * Respond to the client making the request.
+   * @param response The response details to use in the `Response` object.
+   * @returns A native Response.
+   */
+  #respond(response: Drash.Response): Response {
+    if (response.upgraded && response.upgraded_response) {
+      return response.upgraded_response;
+    }
+
+    return new Response(response.body, {
+      headers: response.headers,
+      statusText: response.statusText,
+      status: response.status,
+    });
+  };
 }

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -51,7 +51,7 @@ export class Server {
    * a url pattern for every path specified. This means when a request
    * comes in, the paths are already converted to patterns, saving us time
    */
-  readonly #resources: Drash.Types.ResourcesAndPatternsMap= new Map();
+  readonly #resources: Drash.Types.ResourcesAndPatternsMap = new Map();
 
   /**
    * Our server instance that is serving the app
@@ -199,7 +199,7 @@ export class Server {
       if (service.runAtStartup) {
         await service.runAtStartup({
           server: this,
-          resources: this.#resources
+          resources: this.#resources,
         });
       }
     });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -179,8 +179,8 @@ export interface IService {
 }
 
 export interface IServiceStartupOptions {
-  server: Server,
-  resources: Types.ResourcesAndPatternsMap,
+  server: Server;
+  resources: Types.ResourcesAndPatternsMap;
 }
 
 export interface IErrorHandler {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,7 +4,6 @@ import {
   Resource,
   Response,
   Server,
-  Service,
   Types,
 } from "../mod.ts";
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,7 +3,9 @@ import {
   Request as DrashRequest,
   Resource,
   Response,
+  Server,
   Service,
+  Types,
 } from "../mod.ts";
 
 // This file contains ALL interfaces used by Drash. As a result, it is a very
@@ -172,6 +174,11 @@ export interface IService {
    * Method that runs during server build time.
    */
   runAtStartup?: (options: IServiceStartupOptions) => void | Promise<void>;
+}
+
+export interface IServiceStartupOptions {
+  server: Server,
+  resources: Types.ResourcesAndPatternsMap,
 }
 
 export interface IErrorHandler {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -167,6 +167,11 @@ export interface IService {
     request: DrashRequest,
     response: Response,
   ) => void | Promise<void>;
+
+  /**
+   * Method that runs during server build time.
+   */
+  runAtStartup?: (options: IServiceStartupOptions) => void | Promise<void>;
 }
 
 export interface IErrorHandler {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -192,3 +192,10 @@ export interface IErrorHandler {
     response: Response,
   ) => void | Promise<void>;
 }
+
+export interface IResourceAndParams {
+  /** The instantiated resource class. */
+  resource: Resource;
+  /** The instantiated resource class' path params (if any). */
+  pathParams: Map<string, string>;
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -124,16 +124,16 @@ export interface IResource {
 }
 
 export interface IResourceServices {
-  CONNECT?: Service[];
-  DELETE?: Service[];
-  GET?: Service[];
-  HEAD?: Service[];
-  OPTIONS?: Service[];
-  PATCH?: Service[];
-  POST?: Service[];
-  PUT?: Service[];
-  TRACE?: Service[];
-  ALL?: Service[];
+  CONNECT?: IService[];
+  DELETE?: IService[];
+  GET?: IService[];
+  HEAD?: IService[];
+  OPTIONS?: IService[];
+  PATCH?: IService[];
+  POST?: IService[];
+  PUT?: IService[];
+  TRACE?: IService[];
+  ALL?: IService[];
 }
 
 /**
@@ -148,12 +148,14 @@ export interface IServerOptions {
   port: number;
   protocol: "http" | "https";
   resources: typeof Resource[];
-  services?: Service[];
+  services?: IService[];
   // deno-lint-ignore no-explicit-any camelcase
   error_handler?: new (...args: any[]) => IErrorHandler;
 }
 
 export interface IService {
+  send: boolean;
+
   /**
    * Method that is ran before a resource is handled
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { Request, Resource, Response } from "../mod.ts";
+
 /**
  * The allowed types for an HTTP method on a resource.
  */
@@ -20,3 +22,13 @@ export type BodyFile = {
 };
 
 export type HttpHeadersKeyValuePairs = Record<string, string>;
+
+export type ResourcesAndPatternsMap = Map<number, {
+  resource: Resource;
+  patterns: URLPattern[];
+}>;
+
+export type ResourceHttpMethodHandler = (
+  request: Request,
+  response: Response,
+) => Promise<void> | void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * The allowed types for an HTTP method on a resource.
  */
-export type THttpMethod =
+export type HttpMethodName =
   | "CONNECT"
   | "DELETE"
   | "GET"

--- a/tests/integration/service_run_at_startup.ts
+++ b/tests/integration/service_run_at_startup.ts
@@ -1,0 +1,99 @@
+import {
+  Interfaces,
+  Request,
+  Resource,
+  Response,
+  Server,
+  Service,
+} from "../../mod.ts";
+import { assertEquals } from "../deps.ts";
+
+// Default resource to add to the server (all tests should be able to see this resource)
+class DefaultResource extends Resource {
+  paths = ["/"];
+  public GET(_request: Request, response: Response) {
+    response.text("Hello from DefaultResource");
+  }
+}
+
+// This resource should be added when `ServerService` is plugged into the server
+class AddedResource extends Resource {
+  public paths = ["/added-resource"];
+
+  public GET(request: Request, response: Response): void {
+    const queryParam = request.queryParam("some_query_param");
+    if (queryParam) {
+      return response.text(
+        `Hello from AddedResource. You passed in a "some_query_param" value: ${queryParam}`,
+      );
+    }
+
+    response.text(
+      "Hello from AddedResource. You did not pass in a query param.",
+    );
+  }
+}
+
+// This service should add `AddedResource` to the server
+class ServerService extends Service {
+  runAtStartup(options: Interfaces.IServiceStartupOptions) {
+    const { server } = options;
+    server.addResource(AddedResource);
+  }
+}
+
+/**
+ * Get the fully qualified URL given the URI.
+ *
+ * @param uri - The URI to add to the serverURL.
+ * @returns The fully qualified URL.
+ */
+function url(server: Server, uri: string): string {
+  return server.address + uri;
+}
+
+Deno.test("ServerService should add AddedResource at startup", async () => {
+  const server = new Server({
+    protocol: "http",
+    port: 1234,
+    hostname: "localhost",
+    // `AddedResource` is not present, but it should exist when `ServerService` is instantiated
+    resources: [DefaultResource],
+    services: [new ServerService()],
+  });
+
+  server.run();
+
+  // Assert that the `DeafultResource` is accessible
+  const res1 = await fetch(url(server, "/"));
+  const res1Text = await res1.text();
+  assertEquals(res1Text, "Hello from DefaultResource");
+
+  // Assert that the `AddedResource` is accessible since `ServerService` added it
+  const res2 = await fetch(url(server, "/added-resource"));
+  const res2Text = await res2.text();
+  assertEquals(
+    res2Text,
+    "Hello from AddedResource. You did not pass in a query param.",
+  );
+
+  // Assert (for sanity check) that `AddedResource` takes query params as expected
+  const res3 = await fetch(url(server, "/added-resource?some_query_param=sup"));
+  const res3Text = await res3.text();
+  assertEquals(
+    res3Text,
+    `Hello from AddedResource. You passed in a "some_query_param" value: sup`,
+  );
+
+  // Assert (for sanity check) that `AddedResource` works with other query param values as expected
+  const res4 = await fetch(
+    url(server, "/added-resource?some_query_param=anotha one"),
+  );
+  const res4Text = await res4.text();
+  assertEquals(
+    res4Text,
+    `Hello from AddedResource. You passed in a "some_query_param" value: anotha one`,
+  );
+
+  await server.close();
+});


### PR DESCRIPTION
## Summary

* Placed types and interfaces to be reused in `interfaces.ts` and `types.ts`
* Added `runAtStartup` to service interface
* Added `Server.addResource()`.
* Refactored server to allow services to run at startup
* Removed `T` prefix from types. I don't know why I started doing this, but they're obviously types because they come from the `types.ts` file. woooooOoOopz.
* Started effort to move our server to expect a service interface as opposed to the `Service` class (kind of like how we're doing it for the error handler -- we expect an interface, not a class)