### PR TITLE
refactor: add respond() function to consolidate returning responses in request handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ doc_blocks_output_actual.json
 package-lock.json
 
 # directories
+.vim
 .sass-cache
 tmp*/*
 tmp/*

--- a/deps.ts
+++ b/deps.ts
@@ -2,19 +2,19 @@ const decoder = new TextDecoder();
 const encoder = new TextEncoder();
 export { decoder, encoder };
 
-export { STATUS_TEXT } from "https://deno.land/std@0.128.0/http/http_status.ts";
+export { STATUS_TEXT } from "https://deno.land/std@0.130.0/http/http_status.ts";
 
 export {
   deleteCookie,
   getCookies,
   setCookie,
-} from "https://deno.land/std@0.128.0/http/cookie.ts";
+} from "https://deno.land/std@0.130.0/http/cookie.ts";
 
-export type { Cookie } from "https://deno.land/std@0.128.0/http/cookie.ts";
+export type { Cookie } from "https://deno.land/std@0.130.0/http/cookie.ts";
 
-export { deferred } from "https://deno.land/std@0.128.0/async/deferred.ts";
+export { deferred } from "https://deno.land/std@0.130.0/async/deferred.ts";
 
 export {
   Server as StdServer,
-} from "https://deno.land/std@0.128.0/http/server.ts";
-export type { ConnInfo } from "https://deno.land/std@0.128.0/http/server.ts";
+} from "https://deno.land/std@0.130.0/http/server.ts";
+export type { ConnInfo } from "https://deno.land/std@0.130.0/http/server.ts";

--- a/tests/integration/https_test.ts
+++ b/tests/integration/https_test.ts
@@ -37,7 +37,7 @@ const server = new Server({
 ////////////////////////////////////////////////////////////////////////////////
 
 Rhum.testPlan("browser_request_resource.ts", () => {
-  Rhum.testSuite("GET /browser-request", () => {
+  Rhum.testSuite("GET (https) /browser-request", () => {
     Rhum.testCase("Response should be JSON", async () => {
       server.run();
       // Example browser request

--- a/tests/unit/services/cors_test.ts
+++ b/tests/unit/services/cors_test.ts
@@ -60,7 +60,7 @@ Rhum.testPlan("cors/tests/mod_test.ts", () => {
         response.headers.get("access-control-allow-methods"),
         "GET,HEAD,PUT,PATCH,POST,DELETE",
       );
-      Rhum.asserts.assertEquals(response.headers.get("vary"), "origin");
+      Rhum.asserts.assertEquals(response.headers.get("vary"), "Accept-Encoding, origin");
       Rhum.asserts.assertEquals(response.headers.get("content-length"), null);
       await server.close();
     });
@@ -75,7 +75,7 @@ Rhum.testPlan("cors/tests/mod_test.ts", () => {
         },
       });
       await server.close();
-      Rhum.asserts.assertEquals(response.headers.get("vary"), "origin");
+      Rhum.asserts.assertEquals(response.headers.get("vary"), "Accept-Encoding, origin");
     });
     Rhum.testCase(
       "Only sets the vary header if Origin header is not set",
@@ -90,7 +90,7 @@ Rhum.testPlan("cors/tests/mod_test.ts", () => {
         });
         await response.arrayBuffer();
         await server.close();
-        Rhum.asserts.assertEquals(response.headers.get("vary"), "origin");
+        Rhum.asserts.assertEquals(response.headers.get("vary"), "Accept-Encoding, origin");
         Rhum.asserts.assertEquals(
           response.headers.get("access-control-allow-origin"),
           null,
@@ -115,7 +115,7 @@ Rhum.testPlan("cors/tests/mod_test.ts", () => {
         });
         await response.arrayBuffer();
         await server.close();
-        Rhum.asserts.assertEquals(response.headers.get("vary"), "origin");
+        Rhum.asserts.assertEquals(response.headers.get("vary"), "Accept-Encoding, origin");
         Rhum.asserts.assertEquals(
           response.headers.get("access-control-allow-origin"),
           null,


### PR DESCRIPTION
## Summary

* Adds `respond(response: Drash.Response) => Response` in request handler so that services can do ...
  ```typescript
  if (endLifecycle) { return respond(response); }
  ```
  ... and the request handler and its `catch` block can do ...
  ```typescript
  return respond(response)
  ```
  The `respond(response: Drash.Response) => Response` also includes checking if responses were upgraded in case a service upgrades a response early in the lifecycle.
* Refactored `runServices()` to just return `end`. Reason being, currently in `service-send` branch, if a service throws an error, then we throw that error as soon as possible in the request handler. Instead, we can just not catch the error in `runServices()`, let `runServices()` throw that error to the request handler, then the request handler catches it in its `catch` block. This approach removes the following blocks for each `runServices()` call in the request handler:
  ```typescript
  if (servicesResponse.err) {
    throw servicesResponse.err;
  }
  ```
* Upgraded to Deno v1.20.1 and Deno Std 0.130.0
* Fixed CORS test because of Deno Std 0.130.0 automatically compression response bodies based on Accept-Encoding header. See https://deno.land/manual/runtime/http_server_apis#automatic-body-compression.
