### PR TITLE
fix: ensure consistent falsy return values for body params

### DIFF
--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -12,7 +12,7 @@ export type ParsedBody =
  * A class that holds the representation of an incoming request
  */
 export class DrashRequest extends Request {
-  #parsed_body!: ParsedBody;
+  #parsed_body?: ParsedBody;
   readonly #path_params: Map<string, string>;
   #search_params!: URLSearchParams;
   public conn_info: ConnInfo;
@@ -146,15 +146,27 @@ export class DrashRequest extends Request {
    *
    * @param name The body parameter name
    *
-   * @returns The value of the parameter if found, or undefined if not found.
+   * @returns The value of the parameter if found, or `undefined` if not found.
    */
   public bodyParam<T>(name: string): T | undefined {
+    if (this.#parsed_body === undefined) {
+      return undefined;
+    }
+
     if (typeof this.#parsed_body !== "object") {
       return undefined;
     }
-    return this.#parsed_body[name] as unknown as T ?? undefined;
+
+    if (this.#parsed_body[name] === undefined) {
+      return undefined;
+    }
+
+    return this.#parsed_body[name] as unknown as T;
   }
 
+  /**
+   * Get all body params.
+   */
   public bodyAll<T>(): ParsedBody | T {
     return this.#parsed_body;
   }

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -166,8 +166,19 @@ export class DrashRequest extends Request {
 
   /**
    * Get all body params.
+   *
+   * @returns All params contained in the body or an empty body if no params
+   * exist.
    */
   public bodyAll<T>(): ParsedBody | T {
+    if (this.#parsed_body === undefined) {
+      return {};
+    }
+
+    if (typeof this.#parsed_body !== "object") {
+      return {};
+    }
+
     return this.#parsed_body;
   }
 

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -303,7 +303,7 @@ async function bodyTests(t: Deno.TestContext) {
   );
 
   await t.step(
-    "Should be consistent with falsey return values",
+    "Should be consistent with falsey return values (null value returns null)",
     async () => {
       // This test case was added due to https://github.com/drashland/drash/issues/623
 
@@ -329,11 +329,79 @@ async function bodyTests(t: Deno.TestContext) {
       const body = request.bodyAll() as {
         foo: null;
       };
-      assertEquals(body, {
-        foo: null,
-      });
+      assertEquals(body, { foo: null });
       assertEquals(body["foo"], null);
+      assertEquals(request.bodyParam("foo"), null);
+      // As an edge case check, make sure bodyAll() returns the expected
+      assertEquals((request.bodyAll() as Partial<{foo: unknown}>)["foo"], null);
+    },
+  );
+
+  await t.step(
+    "Should be consistent with falsey return values (undefined value returns undefined)",
+    async () => {
+      // This test case was added due to https://github.com/drashland/drash/issues/623
+
+      const serverRequest = new Request("https://drash.land", {
+        headers: {
+          // We use `"Content-Length": "1"` to tell Drash.Request that there is
+          // a request body. This is a hack just for unit testing. In the real
+          // world, the Content-Length header will be defined (at least it
+          // should be) by the client.
+          "Content-Length": "1",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          foo: undefined
+        }),
+        method: "POST",
+      });
+      const request = await Drash.Request.create(
+        serverRequest,
+        new Map(),
+        connInfo,
+      );
+      const body = request.bodyAll() as Partial<{
+        foo: unknown
+      }>;
+      assertEquals(body, {});
+      assertEquals(body["foo"], undefined);
       assertEquals(request.bodyParam("foo"), undefined);
+      // As an edge case check, make sure bodyAll() returns the expected
+      assertEquals((request.bodyAll() as Partial<{foo: unknown}>)["foo"], undefined);
+    },
+  );
+
+  await t.step(
+    "Should be consistent with falsey return values (no value returns undefined)",
+    async () => {
+      // This test case was added due to https://github.com/drashland/drash/issues/623
+
+      const serverRequest = new Request("https://drash.land", {
+        headers: {
+          // We use `"Content-Length": "1"` to tell Drash.Request that there is
+          // a request body. This is a hack just for unit testing. In the real
+          // world, the Content-Length header will be defined (at least it
+          // should be) by the client.
+          "Content-Length": "1",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+        method: "POST",
+      });
+      const request = await Drash.Request.create(
+        serverRequest,
+        new Map(),
+        connInfo,
+      );
+      const body = request.bodyAll() as Partial<{
+        foo: unknown;
+      }>;
+      assertEquals(body, {});
+      assertEquals(body["foo"], undefined);
+      assertEquals(request.bodyParam("foo"), undefined);
+      // As an edge case check, make sure bodyAll() returns the expected
+      assertEquals((request.bodyAll() as Partial<{foo: unknown}>)["foo"], undefined);
     },
   );
 

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -341,6 +341,44 @@ async function bodyTests(t: Deno.TestContext) {
   );
 
   await t.step(
+    "Should be consistent with falsey return values (false value returns false)",
+    async () => {
+      // This test case was added due to https://github.com/drashland/drash/issues/623
+
+      const serverRequest = new Request("https://drash.land", {
+        headers: {
+          // We use `"Content-Length": "1"` to tell Drash.Request that there is
+          // a request body. This is a hack just for unit testing. In the real
+          // world, the Content-Length header will be defined (at least it
+          // should be) by the client.
+          "Content-Length": "1",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          foo: false,
+        }),
+        method: "POST",
+      });
+      const request = await Drash.Request.create(
+        serverRequest,
+        new Map(),
+        connInfo,
+      );
+      const body = request.bodyAll() as Partial<{
+        foo: unknown;
+      }>;
+      assertEquals(body, { foo: false });
+      assertEquals(body["foo"], false);
+      assertEquals(request.bodyParam("foo"), false);
+      // As an edge case check, make sure bodyAll() returns the expected
+      assertEquals(
+        (request.bodyAll() as Partial<{ foo: unknown }>)["foo"],
+        false,
+      );
+    },
+  );
+
+  await t.step(
     "Should be consistent with falsey return values (undefined value returns undefined)",
     async () => {
       // This test case was added due to https://github.com/drashland/drash/issues/623

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -333,7 +333,10 @@ async function bodyTests(t: Deno.TestContext) {
       assertEquals(body["foo"], null);
       assertEquals(request.bodyParam("foo"), null);
       // As an edge case check, make sure bodyAll() returns the expected
-      assertEquals((request.bodyAll() as Partial<{foo: unknown}>)["foo"], null);
+      assertEquals(
+        (request.bodyAll() as Partial<{ foo: unknown }>)["foo"],
+        null,
+      );
     },
   );
 
@@ -352,7 +355,7 @@ async function bodyTests(t: Deno.TestContext) {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          foo: undefined
+          foo: undefined,
         }),
         method: "POST",
       });
@@ -362,13 +365,16 @@ async function bodyTests(t: Deno.TestContext) {
         connInfo,
       );
       const body = request.bodyAll() as Partial<{
-        foo: unknown
+        foo: unknown;
       }>;
       assertEquals(body, {});
       assertEquals(body["foo"], undefined);
       assertEquals(request.bodyParam("foo"), undefined);
       // As an edge case check, make sure bodyAll() returns the expected
-      assertEquals((request.bodyAll() as Partial<{foo: unknown}>)["foo"], undefined);
+      assertEquals(
+        (request.bodyAll() as Partial<{ foo: unknown }>)["foo"],
+        undefined,
+      );
     },
   );
 
@@ -401,7 +407,10 @@ async function bodyTests(t: Deno.TestContext) {
       assertEquals(body["foo"], undefined);
       assertEquals(request.bodyParam("foo"), undefined);
       // As an edge case check, make sure bodyAll() returns the expected
-      assertEquals((request.bodyAll() as Partial<{foo: unknown}>)["foo"], undefined);
+      assertEquals(
+        (request.bodyAll() as Partial<{ foo: unknown }>)["foo"],
+        undefined,
+      );
     },
   );
 

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -333,7 +333,7 @@ async function bodyTests(t: Deno.TestContext) {
         foo: null,
       });
       assertEquals(body["foo"], null);
-      assertEquals(request.bodyParam("foo"), null);
+      assertEquals(request.bodyParam("foo"), undefined);
     },
   );
 

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -303,6 +303,41 @@ async function bodyTests(t: Deno.TestContext) {
   );
 
   await t.step(
+    "Should be consistent with falsey return values",
+    async () => {
+      // This test case was added due to https://github.com/drashland/drash/issues/623
+
+      const serverRequest = new Request("https://drash.land", {
+        headers: {
+          // We use `"Content-Length": "1"` to tell Drash.Request that there is
+          // a request body. This is a hack just for unit testing. In the real
+          // world, the Content-Length header will be defined (at least it
+          // should be) by the client.
+          "Content-Length": "1",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          foo: null,
+        }),
+        method: "POST",
+      });
+      const request = await Drash.Request.create(
+        serverRequest,
+        new Map(),
+        connInfo,
+      );
+      const body = request.bodyAll() as {
+        foo: null;
+      };
+      assertEquals(body, {
+        foo: null,
+      });
+      assertEquals(body["foo"], null);
+      assertEquals(request.bodyParam("foo"), null);
+    },
+  );
+
+  await t.step(
     "Returns the value for the parameter when it exists and request is multipart/form-data when using generics",
     async () => {
       const formData = new FormData();


### PR DESCRIPTION
closes #623 
