### PR TITLE
perf: don't find resource if already matched to previous request URL

### DIFF
--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -76,6 +76,13 @@ export class Server {
   #default_error_handler = new Drash.ErrorHandler();
 
   /**
+   * Property to track request URLs to resources. This is used so that the
+   * server does not have to find a resource if it was already matched to a
+   * previous request's URL.
+   */
+  #request_to_resource_map = new Map<string, Drash.Interfaces.IResourceAndParams>();
+
+  /**
    * The internal and external services used by this server. Internal services
    * are ones created by Drash. External services are ones specified by the
    * user.
@@ -214,6 +221,10 @@ export class Server {
     let resourceAndParams: Drash.Interfaces.IResourceAndParams | undefined =
       undefined;
 
+    if (this.#request_to_resource_map.has(url)) {
+      return this.#request_to_resource_map.get(url)!;
+    }
+
     for (const { resource, patterns } of resources.values()) {
       for (const pattern of patterns) {
         const result = pattern.exec(url);
@@ -233,6 +244,8 @@ export class Server {
           resource,
           pathParams: params,
         };
+
+        this.#request_to_resource_map.set(url, resourceAndParams);
         break;
       }
     }

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -80,7 +80,10 @@ export class Server {
    * server does not have to find a resource if it was already matched to a
    * previous request's URL.
    */
-  #request_to_resource_map = new Map<string, Drash.Interfaces.IResourceAndParams>();
+  #request_to_resource_map = new Map<
+    string,
+    Drash.Interfaces.IResourceAndParams
+  >();
 
   /**
    * The internal and external services used by this server. Internal services


### PR DESCRIPTION
Closes #636 

Before:

```
Running 10s test @ http://localhost:1447?test=test
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   141.61ms  175.94ms   1.97s    95.86%
    Req/Sec   424.22     85.40   640.00     73.37%
  8498 requests in 10.10s, 4.51MB read
  Socket errors: connect 0, read 0, write 0, timeout 11
  Non-2xx or 3xx responses: 8498
Requests/sec:    841.39
Transfer/sec:    456.85K
```

After:

```
Running 10s test @ http://localhost:1447
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.46ms    2.91ms 100.13ms   99.54%
    Req/Sec    21.55k     1.24k   22.50k    98.02%
  433043 requests in 10.10s, 56.58MB read
Requests/sec:  42867.70
Transfer/sec:      5.60MB
```