### PR TITLE
fix: check for non-empty accept header before performing accept header flow

### DIFF
--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -371,15 +371,14 @@ export class Server {
         return this.#respond(response);
       }
 
-      const accept = request.headers.get("accept") ?? "";
-      const contentType = response.headers.get("content-type") ?? "";
-      if (accept && accept.trim() != "" && accept.includes("*/*") === false) {
-        if (accept.includes(contentType) === false) {
-          throw new Drash.Errors.HttpError(
-            406,
-            "The requested resource is only capable of returning content that is not acceptable according to the request's Accept headers.",
-          );
-        }
+      const requestAcceptHeader = request.headers.get("accept");
+      const responseContentTypeHeader = response.headers.get("content-type");
+
+      if (requestAcceptHeader && responseContentTypeHeader) {
+        this.#verifyAcceptHeader(
+          requestAcceptHeader,
+          responseContentTypeHeader,
+        );
       }
 
       return this.#respond(response);
@@ -409,5 +408,30 @@ export class Server {
       statusText: response.statusText,
       status: response.status,
     });
+  }
+
+  /**
+   * If the request Accept header is present, then make sure the response
+   * Content-Type header is accepted.
+   *
+   * @param requestAcceptHeader
+   * @param responseContentTypeHeader
+   */
+  #verifyAcceptHeader(
+    requestAcceptHeader: string,
+    responseContentTypeHeader: string,
+  ): void {
+    if (requestAcceptHeader.includes("*/*")) {
+      return;
+    }
+
+    if (requestAcceptHeader.includes(responseContentTypeHeader)) {
+      return;
+    }
+
+    throw new Drash.Errors.HttpError(
+      406,
+      "The requested resource is only capable of returning content that is not acceptable according to the request's Accept headers.",
+    );
   }
 }

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -373,7 +373,7 @@ export class Server {
 
       const accept = request.headers.get("accept") ?? "";
       const contentType = response.headers.get("content-type") ?? "";
-      if (accept.includes("*/*") === false) {
+      if (accept && accept.trim() != "" && accept.includes("*/*") === false) {
         if (accept.includes(contentType) === false) {
           throw new Drash.Errors.HttpError(
             406,


### PR DESCRIPTION
Closes #635

Before:

```
Running 5s test @ http://localhost:1447?test=test
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   162.52ms  253.89ms   1.99s    92.58%
    Req/Sec   473.68     72.50   643.00     73.00%
  4796 requests in 5.09s, 2.54MB read
  Non-2xx or 3xx responses: 4796
Requests/sec:    941.74
Transfer/sec:    511.34KB
```

After:

```
Running 5s test @ http://localhost:1447?test=test
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.74ms    5.18ms 124.77ms   99.08%
    Req/Sec    14.80k     1.48k   15.78k    90.20%
  150207 requests in 5.10s, 19.63MB read
Requests/sec:  29431.85
Transfer/sec:      3.85MB
```