### PR TITLE
feat: remove GraphQL service empty resource requirement; add option to change playground endpoint

### DIFF
--- a/src/services/graphql/deps.ts
+++ b/src/services/graphql/deps.ts
@@ -1,3 +1,4 @@
+export * as Drash from "../../../mod.ts";
 export * as GraphQL from "https://cdn.skypack.dev/graphql@15.5.0?dts";
 // TODO ENSURE DMM UPDATES THIS
 export { renderPlaygroundPage } from "https://deno.land/x/gql@1.1.1/graphiql/render.ts";

--- a/src/services/graphql/graphql.ts
+++ b/src/services/graphql/graphql.ts
@@ -1,4 +1,9 @@
-import { Drash, ExecutionResult, GraphQL, renderPlaygroundPage } from "./deps.ts";
+import {
+  Drash,
+  ExecutionResult,
+  GraphQL,
+  renderPlaygroundPage,
+} from "./deps.ts";
 import { GraphQLResource } from "./graphql_resource.ts";
 export { GraphQL };
 
@@ -48,10 +53,10 @@ export class GraphQLService extends Drash.Service {
       return class UserDefinedGraphQLResource extends GraphQLResource {
         public paths = [serviceOptions.playground_path!];
         public services = {
-          ALL: [this as unknown as Drash.Service]
+          ALL: [this as unknown as Drash.Service],
         };
-      }
-    }
+      };
+    };
 
     options.server.addResource(createUserDefinedPlayground());
   }

--- a/src/services/graphql/graphql_resource.ts
+++ b/src/services/graphql/graphql_resource.ts
@@ -3,7 +3,7 @@ import { Drash } from "./deps.ts";
 export class GraphQLResource extends Drash.Resource {
   public paths = ["/graphql"];
 
-  public GET(request: Drash.Request, response: Drash.Response): void {
+  public GET(_request: Drash.Request, _response: Drash.Response): void {
     // This is intentionally left blank.
     //
     // This is only defined to allow GET requests to the front-end playground.
@@ -11,7 +11,7 @@ export class GraphQLResource extends Drash.Resource {
     // requesting to view the playground at /graphql.
   }
 
-  public POST(request: Drash.Request, response: Drash.Response): void {
+  public POST(_request: Drash.Request, _response: Drash.Response): void {
     // This is intentionally left blank.
     //
     // This is only defined so that POST requests to this resource can be
@@ -19,4 +19,3 @@ export class GraphQLResource extends Drash.Resource {
     // when clients try to make GraphQL queries.
   }
 }
-

--- a/src/services/graphql/graphql_resource.ts
+++ b/src/services/graphql/graphql_resource.ts
@@ -1,0 +1,22 @@
+import { Drash } from "./deps.ts";
+
+export class GraphQLResource extends Drash.Resource {
+  public paths = ["/graphql"];
+
+  public GET(request: Drash.Request, response: Drash.Response): void {
+    // This is intentionally left blank.
+    //
+    // This is only defined to allow GET requests to the front-end playground.
+    // Without this, Drash will throw a 405 Method Not Allowed error when
+    // requesting to view the playground at /graphql.
+  }
+
+  public POST(request: Drash.Request, response: Drash.Response): void {
+    // This is intentionally left blank.
+    //
+    // This is only defined so that POST requests to this resource can be
+    // processed. Without this, Drash will throw a 405 Method Not Allowed error
+    // when clients try to make GraphQL queries.
+  }
+}
+

--- a/tests/integration/graphql_test.ts
+++ b/tests/integration/graphql_test.ts
@@ -20,22 +20,6 @@ const root = {
 
 const graphQL = new GraphQLService({ schema, graphiql: true, rootValue: root });
 
-class GraphQLResource extends Drash.Resource {
-  paths = ["/graphql"];
-
-  services = {
-    ALL: [graphQL],
-  };
-
-  // Used purely as an endpoint for the frontend playground
-  public GET() {
-  }
-
-  // Used purely as an endpoint to make a query from the client
-  public POST() {
-  }
-}
-
 async function serverAction(
   action: "close",
   server: Drash.Server,
@@ -49,10 +33,11 @@ async function serverAction(
 ): Promise<Drash.Server | void> {
   if (action === "run") {
     const server = new Drash.Server({
-      resources: [GraphQLResource],
+      resources: [],
       protocol: "http",
       port: 1337,
       hostname: "localhost",
+      services: [graphQL]
     });
     server.run();
     return server;

--- a/tests/integration/graphql_test.ts
+++ b/tests/integration/graphql_test.ts
@@ -37,7 +37,7 @@ async function serverAction(
       protocol: "http",
       port: 1337,
       hostname: "localhost",
-      services: [graphQL]
+      services: [graphQL],
     });
     server.run();
     return server;


### PR DESCRIPTION
Closes #646 

## TODO

- [x] Update documentation
  - PR: https://github.com/drashland/website-v2/pull/170
  - Page: https://drash-land-git-feat-graphql-improved-docs-drash-land.vercel.app/drash/v2.x/tutorials/services/drash-approved-services/graphql

## Summary

* refactor: `GraphQLService` creates the GraphQL playground resource at startup time
* feat: add option `playground_path` to allow user to define different GraphQL playground endpoint
* test: updates `GraphQLService` test

## Example Usage

```typescript
// app.ts

import { Drash, GraphQL, GraphQLService } from "./deps.ts";

// Set up your GraphQL environment

const schema = GraphQL.buildSchema(`
  type Query {
    greeting: String
  }
`);

const root = {
  greeting: () => { // or greeting: (source, args, context, info) => {
    return "Hello world!";
  },
};

// Instantiate the GraphQL service

const graphQl = new GraphQLService({
  schema,
  graphiql: true,
  rootValue: root,
});

const server = new Drash.Server({
  hostname: "localhost",
  port: 1447,
  protocol: "http",
  resources: [],
  services: [graphQl],
});

server.run();

console.log(`Server running at ${server.address}.`);
```