### PR TITLE
refactor(http/server): allow server to be extended so that users can control handleRequest()

### DIFF
--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1,33 +1,6 @@
 import * as Drash from "../../mod.ts";
 import { ConnInfo, StdServer } from "../../deps.ts";
 
-async function runServices(
-  Services: Drash.Interfaces.IService[],
-  request: Drash.Request,
-  response: Drash.Response,
-  serviceMethod: "runBeforeResource" | "runAfterResource",
-): Promise<void> {
-  // There are two ways a service can short-circuit the
-  // request-resource-response lifecycle:
-  //
-  //   1. The service throws an error.
-  //   2. The service calls `request.end()`.
-  //
-  // If the service throws an error, then the request handler we pass in to `new
-  // StdServer()` will catch it and return a response.
-  //
-  // If the service calls `request.end()`, then the request handler we pass in
-  // to `new StdServer()` will return `new Response()`.
-  for (const Service of Services) {
-    if (serviceMethod in Service) {
-      await Service[serviceMethod]!(request, response);
-      if (request.end_lifecycle) {
-        break;
-      }
-    }
-  }
-}
-
 /**
  * This class handles the entire request-resource-response lifecycle. It is in
  * charge of handling incoming requests, matching them to resources for further
@@ -39,35 +12,25 @@ export class Server {
   /**
    * See Drash.Interfaces.IServerOptions.
    */
-  readonly #options: Drash.Interfaces.IServerOptions;
+  protected readonly options: Drash.Interfaces.IServerOptions;
 
   /**
    * A list of all instanced resources the user specified, and
    * a url pattern for every path specified. This means when a request
    * comes in, the paths are already converted to patterns, saving us time
    */
-  readonly #resources: Drash.Types.ResourcesAndPatternsMap = new Map();
+  protected readonly resources: Drash.Types.ResourcesAndPatternsMap = new Map();
 
   /**
-   * Our server instance that is serving the app
+   * A custom Error object handler.
    */
-  #server!: StdServer;
+  protected error_handler: Drash.Interfaces.IErrorHandler;
 
   /**
    * All services that provide extra functionality to the server and the overall
    * application.
    */
-  #services: Drash.Interfaces.IService[] = [];
-
-  /**
-   * A promise we need to await after calling close() on #server
-   */
-  #server_promise!: Promise<void>;
-
-  /**
-   * A custom Error object handler.
-   */
-  #error_handler!: Drash.Interfaces.IErrorHandler;
+  protected services: Drash.Interfaces.IService[] = [];
 
   /**
    * The error handler to use in the event `this.#error_handler` cannot handle
@@ -80,10 +43,20 @@ export class Server {
    * server does not have to find a resource if it was already matched to a
    * previous request's URL.
    */
-  #request_to_resource_map = new Map<
+  #request_to_resource_proxy_map = new Map<
     string,
-    Drash.Interfaces.IResourceAndParams
+    Drash.Interfaces.IResourceProxy
   >();
+
+  /**
+   * Our server instance that is serving the app
+   */
+  #server!: StdServer;
+
+  /**
+   * A promise we need to await after calling close() on #server
+   */
+  #server_promise!: Promise<void>;
 
   //////////////////////////////////////////////////////////////////////////////
   // FILE MARKER - CONSTRUCTOR /////////////////////////////////////////////////
@@ -93,8 +66,8 @@ export class Server {
    * @param options - See the interface for the options' schema.
    */
   constructor(options: Drash.Interfaces.IServerOptions) {
-    this.#options = options;
-    this.#error_handler = new (options.error_handler || Drash.ErrorHandler)();
+    this.options = options;
+    this.error_handler = new (options.error_handler || Drash.ErrorHandler)();
 
     // Compile the application
     this.#addServices();
@@ -109,7 +82,7 @@ export class Server {
    * Get the full address that this server is running on.
    */
   get address(): string {
-    return `${this.#options.protocol}://${this.#options.hostname}:${this.#options.port}`;
+    return `${this.options.protocol}://${this.options.hostname}:${this.options.port}`;
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -129,7 +102,7 @@ export class Server {
       // Add "{/}?" to match possible trailing slashes too
       patterns.push(new URLPattern({ pathname: path + "{/}?" }));
     });
-    this.#resources.set(this.#resources.size, {
+    this.resources.set(this.resources.size, {
       resource,
       patterns,
     });
@@ -152,102 +125,28 @@ export class Server {
    */
   public run() {
     this.#server = new StdServer({
-      hostname: this.#options.hostname,
-      port: this.#options.port,
+      hostname: this.options.hostname,
+      port: this.options.port,
       handler: async (originalRequest: Request, connInfo: ConnInfo) => {
-        return await this.#handleRequest(originalRequest, connInfo);
+        return await this.handleRequest(originalRequest, connInfo);
       },
     });
 
-    if (this.#options.protocol === "http") {
+    if (this.options.protocol === "http") {
       this.#server_promise = this.#server.listenAndServe();
     }
 
-    if (this.#options.protocol === "https") {
+    if (this.options.protocol === "https") {
       this.#server_promise = this.#server.listenAndServeTls(
-        this.#options.cert_file as string,
-        this.#options.key_file as string,
+        this.options.cert_file as string,
+        this.options.key_file as string,
       );
     }
   }
 
   //////////////////////////////////////////////////////////////////////////////
-  // FILE MARKER - METHODS - PRIVATE ///////////////////////////////////////////
+  // FILE MARKER - METHODS - PROTECTED /////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
-
-  /**
-   * Add all resources to this server -- instantiating them so that they
-   * are ready to handle requests at runtime.
-   */
-  #addResources(): void {
-    this.#options.resources?.forEach((resourceClass: typeof Drash.Resource) => {
-      this.addResource(resourceClass);
-    });
-  }
-
-  /**
-   * Add all given services in the options.
-   */
-  #addServices(): void {
-    if (this.#options.services) {
-      this.#services = this.#options.services;
-    }
-
-    this.#services.forEach(async (service: Drash.Interfaces.IService) => {
-      if (service.runAtStartup) {
-        await service.runAtStartup({
-          server: this,
-          resources: this.#resources,
-        });
-      }
-    });
-  }
-
-  /**
-   * Get the resource associated with the given URL and its path params
-   * associated with it.
-   *
-   * @param url - The URL to match to a resource.
-   * @param resources - The resources map to use to find the resource.
-   */
-  #getResourceAndParams(
-    url: string,
-    resources: Drash.Types.ResourcesAndPatternsMap,
-  ): Drash.Interfaces.IResourceAndParams | undefined {
-    let resourceAndParams: Drash.Interfaces.IResourceAndParams | undefined =
-      undefined;
-
-    if (this.#request_to_resource_map.has(url)) {
-      return this.#request_to_resource_map.get(url)!;
-    }
-
-    for (const { resource, patterns } of resources.values()) {
-      for (const pattern of patterns) {
-        const result = pattern.exec(url);
-
-        // No resource? Check the next one.
-        if (result === null) {
-          continue;
-        }
-
-        // this is the resource we need, and below are the params
-        const params = new Map();
-        for (const key in result.pathname.groups) {
-          params.set(key, result.pathname.groups[key]);
-        }
-
-        resourceAndParams = {
-          resource,
-          pathParams: params,
-        };
-
-        this.#request_to_resource_map.set(url, resourceAndParams);
-        break;
-      }
-    }
-
-    return resourceAndParams;
-  }
 
   /**
    * Handle the given native request. This request gets wrapped around by a
@@ -259,25 +158,20 @@ export class Server {
    *
    * @returns A native response.
    */
-  async #handleRequest(
+  protected async handleRequest(
     originalRequest: Request,
     connInfo: ConnInfo,
   ): Promise<Response> {
     // Grab resource and path params
-    const resourceAndParams = this.#getResourceAndParams(
+    const { instance: resource, pathParams } = this.getResourceProxy(
       originalRequest.url,
-      this.#resources,
-    ) ?? {
-      resource: null,
-      pathParams: new Map(),
-    };
-
-    const { resource, pathParams } = resourceAndParams;
+    );
 
     // Construct request and response objects to pass to services and resource
     // Keep response top level so we can reuse the headers should an error be thrown
     // in the try
     const response = new Drash.Response();
+
     try {
       const request = await Drash.Request.create(
         originalRequest,
@@ -286,8 +180,8 @@ export class Server {
       );
 
       // Run server-level services (before we get to the resource)
-      await runServices(
-        this.#services,
+      await this.runServices(
+        this.services,
         request,
         response,
         "runBeforeResource",
@@ -304,7 +198,7 @@ export class Server {
       }
 
       // Run resource-level services (before their HTTP method is called)
-      await runServices(
+      await this.runServices(
         resource.services.ALL ?? [],
         request,
         response,
@@ -326,7 +220,7 @@ export class Server {
 
       // Run resource HTTP method level services (before the HTTP method is
       // called)
-      await runServices(
+      await this.runServices(
         resource.services[method] ?? [],
         request,
         response,
@@ -345,7 +239,7 @@ export class Server {
 
       // Run resource HTTP method level services (after the HTTP method is
       // called)
-      await runServices(
+      await this.runServices(
         resource.services[method] ?? [],
         request,
         response,
@@ -357,7 +251,7 @@ export class Server {
       }
 
       // Run resource-level services (after the HTTP method is called)
-      await runServices(
+      await this.runServices(
         resource.services.ALL ?? [],
         request,
         response,
@@ -370,8 +264,8 @@ export class Server {
 
       // Run server-level services as a last step before returning a response
       // that the resource has formed
-      await runServices(
-        this.#services,
+      await this.runServices(
+        this.services,
         request,
         response,
         "runAfterResource",
@@ -394,7 +288,7 @@ export class Server {
       return this.#respond(response);
     } catch (e) {
       try {
-        await this.#error_handler.catch(e, originalRequest, response, connInfo);
+        await this.error_handler.catch(e, originalRequest, response, connInfo);
       } catch (e) {
         await this.#default_error_handler.catch(
           e,
@@ -406,6 +300,126 @@ export class Server {
 
       return this.#respond(response);
     }
+  }
+
+  /**
+   * Take the given URL and match it to a resource. If a resource is found,
+   * create a proxy object that holds access to the matched resource instance
+   * and the path params (if any) to use for the resource's path signature (the
+   * one that matched the given URL).
+   *
+   * @param url - The URL to match to a resource.
+   *
+   * @returns A proxy object that holds access to the matched resource instance
+   * and the path params (if any) to use for the resource's path signature (the
+   * one that matched the given URL) See `Drash.Interfaces.IResourceProxy` for
+   * more information.
+   */
+  protected getResourceProxy(url: string): Drash.Interfaces.IResourceProxy {
+    let instanceAndPathParams: Drash.Interfaces.IResourceProxy = {
+      pathParams: new Map<string, string>(),
+    };
+
+    // If the request was already matched to a resource, then return that
+    // resource
+    if (this.#request_to_resource_proxy_map.has(url)) {
+      return this.#request_to_resource_proxy_map.get(url)!;
+    }
+
+    for (const { resource, patterns } of this.resources.values()) {
+      for (const pattern of patterns) {
+        const result = pattern.exec(url);
+
+        // No resource? Check the next one.
+        if (result === null) {
+          continue;
+        }
+
+        // This is the resource we need and below are the path params that match
+        // the resource's path params signature
+        const pathParams = new Map();
+        for (const key in result.pathname.groups) {
+          pathParams.set(key, result.pathname.groups[key]);
+        }
+
+        instanceAndPathParams = {
+          instance: resource,
+          pathParams: pathParams,
+        };
+
+        this.#request_to_resource_proxy_map.set(url, instanceAndPathParams);
+        break;
+      }
+    }
+
+    return instanceAndPathParams;
+  }
+
+  /**
+   * Run services during the request-resource-response lifecycle.
+   *
+   * @param Services
+   * @param request
+   * @param response
+   * @param serviceMethod
+   */
+  protected async runServices(
+    Services: Drash.Interfaces.IService[],
+    request: Drash.Request,
+    response: Drash.Response,
+    serviceMethod: "runBeforeResource" | "runAfterResource",
+  ): Promise<void> {
+    // There are two ways a service can short-circuit the
+    // request-resource-response lifecycle:
+    //
+    //   1. The service throws an error.
+    //   2. The service calls `request.end()`.
+    //
+    // If the service throws an error, then the request handler we pass in to `new
+    // StdServer()` will catch it and return a response.
+    //
+    // If the service calls `request.end()`, then the request handler we pass in
+    // to `new StdServer()` will return `new Response()`.
+    for (const Service of Services) {
+      if (serviceMethod in Service) {
+        await Service[serviceMethod]!(request, response);
+        if (request.end_lifecycle) {
+          break;
+        }
+      }
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // FILE MARKER - METHODS - PRIVATE ///////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * Add all resources to this server -- instantiating them so that they
+   * are ready to handle requests at runtime.
+   */
+  #addResources(): void {
+    this.options.resources?.forEach((resourceClass: typeof Drash.Resource) => {
+      this.addResource(resourceClass);
+    });
+  }
+
+  /**
+   * Add all given services in the options.
+   */
+  #addServices(): void {
+    if (this.options.services) {
+      this.services = this.options.services;
+    }
+
+    this.services.forEach(async (service: Drash.Interfaces.IService) => {
+      if (service.runAtStartup) {
+        await service.runAtStartup({
+          server: this,
+          resources: this.resources,
+        });
+      }
+    });
   }
 
   /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -202,9 +202,15 @@ export interface IErrorHandler {
   catch: Catch;
 }
 
-export interface IResourceAndParams {
-  /** The instantiated resource class. */
-  resource: Resource;
+/**
+ * This proxy is created when an incoming request's URL is matched to a
+ * resource (see the implementation of `Drash.Server.handleRequest()`). Each
+ * incoming request that is matched to a resource uses its own `IResourceProxy`
+ * object for its own context.
+ */
+export interface IResourceProxy {
   /** The instantiated resource class' path params (if any). */
   pathParams: Map<string, string>;
+  /** The instantiated resource class. */
+  instance?: Resource;
 }


### PR DESCRIPTION
## Summary

- Makes the necessary changes to allow extending `Drash.Server` with "little" effort. I say "little" because the only method that needs to be implemented is the `handleRequest()` method. Right now, if a user were to extend `Drash.Server`, they'd have to recreate a bunch of the internals like `runServices()`, which lives outside the `Server` class. In this PR, users can now extend `Drash.Server` and provide their own implementation of `handleRequest()` -- also being able to call the necessary methods to recreate the request-resource-response lifecycle (e.g., they can call `this.runServices()`). Reason for this is to allow people to write what they think is best for handling a request for their server's implementation while still taking advantage of Drash's `Request`, `Resource`, `Response`, and `Service` classes.
- This also makes a change to the method name `this.#getResourceAndParams()` to `this.getResourceProxy()`. Reason I chose proxy was because it seems more fitting, but open to suggestions.
- If we decide to go through with this, then we can't hide what we're currently exposing in this PR, so I think we need to scrutinize this PR before releasing it. Otherwise we might run into a "dang we gotta make a breaking change and go to v3" situation.
- Did some alphabetizing, so the diffs are bigger than they should be 🥶 