### PR TITLE
feat(http/server): add request optionals to control reading the body

### DIFF
--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -72,6 +72,7 @@ export class DrashRequest extends Request {
    * @param pathParams - The path params to match the request's URL to. The path
    * params come from a resource's path(s).
    * @param connInfo - The connection info Deno provides on a new request
+   * @param requestOptions - Any options to control the way requests behave.
    *
    * @returns A Drash request object.
    */
@@ -79,7 +80,7 @@ export class DrashRequest extends Request {
     request: Request,
     pathParams: Map<string, string>,
     connInfo: ConnInfo,
-    requestOptions: RequestOptions,
+    requestOptions?: RequestOptions,
   ) {
     const req = new DrashRequest(request, pathParams, connInfo);
 

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -1,7 +1,7 @@
 import { getCookies } from "../../deps.ts";
 import { Errors } from "../../mod.ts";
 import type { ConnInfo } from "../../deps.ts";
-import { BodyFile, RequestOptionals } from "../types.ts";
+import { BodyFile, RequestOptions } from "../types.ts";
 
 export type ParsedBody =
   | Record<string, string | BodyFile | BodyFile[]>
@@ -79,12 +79,12 @@ export class DrashRequest extends Request {
     request: Request,
     pathParams: Map<string, string>,
     connInfo: ConnInfo,
-    optionals?: RequestOptionals,
+    requestOptions: RequestOptions,
   ) {
     const req = new DrashRequest(request, pathParams, connInfo);
 
-    if (optionals) {
-      if (optionals.read_body === false) {
+    if (requestOptions) {
+      if (requestOptions.read_body === false) {
         return req;
       }
     }

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -72,7 +72,7 @@ export class DrashRequest extends Request {
    * @param pathParams - The path params to match the request's URL to. The path
    * params come from a resource's path(s).
    * @param connInfo - The connection info Deno provides on a new request
-   * @param requestOptions - Any options to control the way requests behave.
+   * @param options - Any options to control the way requests behave.
    *
    * @returns A Drash request object.
    */
@@ -80,12 +80,12 @@ export class DrashRequest extends Request {
     request: Request,
     pathParams: Map<string, string>,
     connInfo: ConnInfo,
-    requestOptions?: RequestOptions,
+    options?: RequestOptions,
   ) {
     const req = new DrashRequest(request, pathParams, connInfo);
 
-    if (requestOptions) {
-      if (requestOptions.read_body === false) {
+    if (options) {
+      if (options.read_body === false) {
         return req;
       }
     }

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -1,7 +1,7 @@
 import { getCookies } from "../../deps.ts";
 import { Errors } from "../../mod.ts";
 import type { ConnInfo } from "../../deps.ts";
-import { BodyFile } from "../types.ts";
+import { BodyFile, RequestOptionals } from "../types.ts";
 
 export type ParsedBody =
   | Record<string, string | BodyFile | BodyFile[]>
@@ -79,8 +79,16 @@ export class DrashRequest extends Request {
     request: Request,
     pathParams: Map<string, string>,
     connInfo: ConnInfo,
+    optionals?: RequestOptionals,
   ) {
     const req = new DrashRequest(request, pathParams, connInfo);
+
+    if (optionals) {
+      if (optionals.read_body === false) {
+        return req;
+      }
+    }
+
     // This is here because `parseBody` is async. We can't parse the request
     // body on the fly as we dont want users to have to use await when getting a
     // body param.

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -278,11 +278,13 @@ export class Server {
     // Keep response top level so we can reuse the headers should an error be thrown
     // in the try
     const response = new Drash.Response();
+
     try {
       const request = await Drash.Request.create(
         originalRequest,
         pathParams,
         connInfo,
+        this.#options.optionals?.request
       );
 
       // Run server-level services (before we get to the resource)

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -284,7 +284,7 @@ export class Server {
         originalRequest,
         pathParams,
         connInfo,
-        this.#options.optionals?.request,
+        this.#options.request ?? {},
       );
 
       // Run server-level services (before we get to the resource)

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -284,7 +284,7 @@ export class Server {
         originalRequest,
         pathParams,
         connInfo,
-        this.#options.optionals?.request
+        this.#options.optionals?.request,
       );
 
       // Run server-level services (before we get to the resource)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,7 +7,7 @@ import {
   Types,
 } from "../mod.ts";
 import type { ConnInfo } from "../deps.ts";
-import { RequestOptionals } from "./types.ts";
+import { RequestOptions } from "./types.ts";
 
 // This file contains ALL interfaces used by Drash. As a result, it is a very
 // large file.
@@ -146,9 +146,7 @@ export interface IServerOptions {
   hostname: string;
   // deno-lint-ignore camelcase
   key_file?: string;
-  optionals?: {
-    request: RequestOptionals;
-  };
+  request?: RequestOptions;
   port: number;
   protocol: "http" | "https";
   resources?: typeof Resource[];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,6 +7,7 @@ import {
   Types,
 } from "../mod.ts";
 import type { ConnInfo } from "../deps.ts";
+import { RequestOptionals } from "./types.ts";
 
 // This file contains ALL interfaces used by Drash. As a result, it is a very
 // large file.
@@ -145,6 +146,9 @@ export interface IServerOptions {
   hostname: string;
   // deno-lint-ignore camelcase
   key_file?: string;
+  optionals: {
+    request: RequestOptionals;
+  };
   port: number;
   protocol: "http" | "https";
   resources?: typeof Resource[];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -146,7 +146,7 @@ export interface IServerOptions {
   hostname: string;
   // deno-lint-ignore camelcase
   key_file?: string;
-  optionals: {
+  optionals?: {
     request: RequestOptionals;
   };
   port: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,3 +32,27 @@ export type ResourceHttpMethodHandler = (
   request: Request,
   response: Response,
 ) => Promise<void> | void;
+
+/**
+ * Optional request configs to use when creating the `Drash.Server` object. This
+ * type describes the `optionals.request` config on the `Drash.Server` object.
+ *
+ * @example
+ *
+ * ```typescript
+ * const server = new Drash.Server({
+ *   ...
+ *   ...
+ *   ...
+ *   optionals: {
+ *     request: {
+ *       read_body: false,
+ *     }
+ *   },
+ * });
+ * ```
+ */
+export type RequestOptionals = Partial<{
+  /** Should incoming requests have their bodies read? */
+  read_body: boolean;
+}>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,8 +34,7 @@ export type ResourceHttpMethodHandler = (
 ) => Promise<void> | void;
 
 /**
- * Optional request configs to use when creating the `Drash.Server` object. This
- * type describes the `optionals.request` config on the `Drash.Server` object.
+ * Request options to use when creating the `Drash.Server` object.
  *
  * @example
  *
@@ -44,15 +43,13 @@ export type ResourceHttpMethodHandler = (
  *   ...
  *   ...
  *   ...
- *   optionals: {
- *     request: {
- *       read_body: false,
- *     }
- *   },
+ *   request: {
+ *     read_body: false,
+ *   }
  * });
  * ```
  */
-export type RequestOptionals = Partial<{
+export type RequestOptions = Partial<{
   /** Should incoming requests have their bodies read? */
   read_body: boolean;
 }>;

--- a/tests/integration/server_with_optionals_request_test.ts
+++ b/tests/integration/server_with_optionals_request_test.ts
@@ -52,10 +52,8 @@ const createServer = (readBody: boolean) =>
     resources: [
       HomeResource,
     ],
-    optionals: {
-      request: {
-        read_body: readBody,
-      },
+    request: {
+      read_body: readBody,
     },
   });
 

--- a/tests/integration/server_with_optionals_request_test.ts
+++ b/tests/integration/server_with_optionals_request_test.ts
@@ -71,7 +71,6 @@ Deno.test("Drash.Server#options.request", async (t) => {
         const server = createServer(true);
         server.run();
 
-        const typeToCheck = "application/json";
         const response = await fetch(
           "http://localhost:1447?method_to_execute=blob",
           {
@@ -93,7 +92,6 @@ Deno.test("Drash.Server#options.request", async (t) => {
         const server = createServer(true);
         server.run();
 
-        const typeToCheck = "application/json";
         const response = await fetch(
           "http://localhost:1447?method_to_execute=json",
           {
@@ -115,7 +113,6 @@ Deno.test("Drash.Server#options.request", async (t) => {
         const server = createServer(true);
         server.run();
 
-        const typeToCheck = "application/json";
         const response = await fetch(
           "http://localhost:1447?method_to_execute=arrayBuffer",
           {
@@ -137,7 +134,6 @@ Deno.test("Drash.Server#options.request", async (t) => {
         const server = createServer(true);
         server.run();
 
-        const typeToCheck = "application/json";
         const response = await fetch(
           "http://localhost:1447?method_to_execute=text",
           {
@@ -159,7 +155,6 @@ Deno.test("Drash.Server#options.request", async (t) => {
         const server = createServer(true);
         server.run();
 
-        const typeToCheck = "application/json";
         const response = await fetch(
           "http://localhost:1447?method_to_execute=formData",
           {
@@ -183,7 +178,6 @@ Deno.test("Drash.Server#options.request", async (t) => {
         const server = createServer(false);
         server.run();
 
-        const typeToCheck = "application/json";
         const response = await fetch(
           "http://localhost:1447?method_to_execute=blob",
           {
@@ -205,7 +199,6 @@ Deno.test("Drash.Server#options.request", async (t) => {
         const server = createServer(false);
         server.run();
 
-        const typeToCheck = "application/json";
         const response = await fetch(
           "http://localhost:1447?method_to_execute=json",
           {
@@ -227,7 +220,6 @@ Deno.test("Drash.Server#options.request", async (t) => {
         const server = createServer(false);
         server.run();
 
-        const typeToCheck = "application/json";
         const response = await fetch(
           "http://localhost:1447?method_to_execute=arrayBuffer",
           {
@@ -249,7 +241,6 @@ Deno.test("Drash.Server#options.request", async (t) => {
         const server = createServer(false);
         server.run();
 
-        const typeToCheck = "application/json";
         const response = await fetch(
           "http://localhost:1447?method_to_execute=text",
           {

--- a/tests/integration/server_with_optionals_request_test.ts
+++ b/tests/integration/server_with_optionals_request_test.ts
@@ -1,0 +1,300 @@
+import * as Drash from "../../mod.ts";
+import { assertEquals } from "../deps.ts";
+
+////////////////////////////////////////////////////////////////////////////////
+// FILE MARKER - APP SETUP /////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+class HomeResource extends Drash.Resource {
+  public paths = [
+    "/",
+  ];
+
+  public async POST(
+    request: Drash.Request,
+    response: Drash.Response,
+  ): Promise<void> {
+    const methodToExecute = request.queryParam("method_to_execute");
+
+    let body: unknown;
+
+    try {
+      switch (methodToExecute) {
+        case "arrayBuffer":
+          body = await request.arrayBuffer();
+          break;
+        case "blob":
+          body = await request.blob();
+          break;
+        case "formData":
+          body = await request.formData();
+          break;
+        case "json":
+          body = JSON.stringify(await request.json());
+          break;
+        case "text":
+        default:
+          body = await request.text();
+          break;
+      }
+      response.text(body as string);
+    } catch (error) {
+      response.text(error.message);
+    }
+  }
+}
+
+const createServer = (readBody: boolean) =>
+  new Drash.Server({
+    hostname: "0.0.0.0",
+    port: 1447,
+    protocol: "http",
+    resources: [
+      HomeResource,
+    ],
+    optionals: {
+      request: {
+        read_body: readBody,
+      },
+    },
+  });
+
+////////////////////////////////////////////////////////////////////////////////
+// FILE MARKER - TESTS /////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+Deno.test("Drash.Server#options.request", async (t) => {
+  await t.step("read_body: true", async (t) => {
+    await t.step(
+      "calling request.blob() returns 'Body already consumed' response",
+      async () => {
+        const server = createServer(true);
+        server.run();
+
+        const typeToCheck = "application/json";
+        const response = await fetch(
+          "http://localhost:1447?method_to_execute=blob",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              something: "random",
+            }),
+          },
+        );
+        const res = await response.text();
+        assertEquals(res, "Body already consumed.");
+        await server.close();
+      },
+    );
+
+    await t.step(
+      "calling request.json() returns 'Body already consumed' response",
+      async () => {
+        const server = createServer(true);
+        server.run();
+
+        const typeToCheck = "application/json";
+        const response = await fetch(
+          "http://localhost:1447?method_to_execute=json",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              something: "random",
+            }),
+          },
+        );
+        const res = await response.text();
+        assertEquals(res, "Body already consumed.");
+        await server.close();
+      },
+    );
+
+    await t.step(
+      "calling request.arrayBuffer() returns 'Body already consumed' response",
+      async () => {
+        const server = createServer(true);
+        server.run();
+
+        const typeToCheck = "application/json";
+        const response = await fetch(
+          "http://localhost:1447?method_to_execute=arrayBuffer",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              something: "random",
+            }),
+          },
+        );
+        const res = await response.text();
+        assertEquals(res, "Body already consumed.");
+        await server.close();
+      },
+    );
+
+    await t.step(
+      "calling request.text() returns 'Body already consumed' response",
+      async () => {
+        const server = createServer(true);
+        server.run();
+
+        const typeToCheck = "application/json";
+        const response = await fetch(
+          "http://localhost:1447?method_to_execute=text",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              something: "random",
+            }),
+          },
+        );
+        const res = await response.text();
+        assertEquals(res, "Body already consumed.");
+        await server.close();
+      },
+    );
+
+    await t.step(
+      "calling request.formData() returns 'Body already consumed' response",
+      async () => {
+        const server = createServer(true);
+        server.run();
+
+        const typeToCheck = "application/json";
+        const response = await fetch(
+          "http://localhost:1447?method_to_execute=formData",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              something: "random",
+            }),
+          },
+        );
+        const res = await response.text();
+        assertEquals(res, "Body already consumed.");
+        await server.close();
+      },
+    );
+  });
+
+  await t.step("read_body: false", async (t) => {
+    await t.step(
+      "calling request.blob() returns body that was sent in request",
+      async () => {
+        const server = createServer(false);
+        server.run();
+
+        const typeToCheck = "application/json";
+        const response = await fetch(
+          "http://localhost:1447?method_to_execute=blob",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              something: "random",
+            }),
+          },
+        );
+        const res = await response.text();
+        assertEquals(res, `{"something":"random"}`);
+        await server.close();
+      },
+    );
+
+    await t.step(
+      "calling request.json() returns body that was sent in request",
+      async () => {
+        const server = createServer(false);
+        server.run();
+
+        const typeToCheck = "application/json";
+        const response = await fetch(
+          "http://localhost:1447?method_to_execute=json",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              something: "random",
+            }),
+          },
+        );
+        const res = await response.text();
+        assertEquals(res, `{"something":"random"}`);
+        await server.close();
+      },
+    );
+
+    await t.step(
+      "calling request.arrayBuffer() returns body that was sent in request",
+      async () => {
+        const server = createServer(false);
+        server.run();
+
+        const typeToCheck = "application/json";
+        const response = await fetch(
+          "http://localhost:1447?method_to_execute=arrayBuffer",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              something: "random",
+            }),
+          },
+        );
+        const res = await response.text();
+        assertEquals(res, `{"something":"random"}`);
+        await server.close();
+      },
+    );
+
+    await t.step(
+      "calling request.text() returns body that was sent in request",
+      async () => {
+        const server = createServer(false);
+        server.run();
+
+        const typeToCheck = "application/json";
+        const response = await fetch(
+          "http://localhost:1447?method_to_execute=text",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              something: "random",
+            }),
+          },
+        );
+        const res = await response.text();
+        assertEquals(res, `{"something":"random"}`);
+        await server.close();
+      },
+    );
+
+    await t.step(
+      "calling request.formData() returns body that was sent in request",
+      async () => {
+        const server = createServer(false);
+        server.run();
+
+        const formData = new FormData();
+        const file = new Blob([
+          new File([new ArrayBuffer(10)], "mod.ts"),
+        ], {
+          type: "application/javascript",
+        });
+        formData.append("foo[]", file, "mod.ts");
+
+        const response = await fetch(
+          "http://localhost:1447?method_to_execute=formData",
+          {
+            method: "POST",
+            body: formData,
+          },
+        );
+
+        const res = await response.text();
+        const cd = `Content-Disposition: form-data;`;
+        const name = `name="foo[]"; filename="mod.ts"`;
+
+        assertEquals(res.includes(cd), true);
+        assertEquals(res.includes(name), true);
+        await server.close();
+      },
+    );
+  });
+});


### PR DESCRIPTION
Closes #669 

## Summary

Adds an `optionals` server config that takes in a `request` optionals object. We can use this `optionals` config to introduce changes to different HTTP objects if needed.

Example:

```typescript
import * as Drash from "/path/to/drash/mod.ts";

class HomeResource extends Drash.Resource {
  public paths = [
    "/",
  ];

  public async POST(
    request: Drash.Request,
    response: Drash.Response,
  ): Promise<void> {
    // Since the body was not read, users can call the request methods themselves
    const body = await request.blob();

    console.log(body); // Example output => Blob { size: 15, type: "image/png" }

    response.text("Hello");
  }
}

const server = new Drash.Server({
  hostname: "0.0.0.0",
  port: 1447,
  protocol: "http",
  resources: [
    HomeResource,
  ],
  optionals: {
    request: {
      read_body: false, // Prevents the Drash.Request object from reading the body when it's created
    }
  }
});

server.run();

console.log(`Server running at ${server.address}.`);
```

@ebebbington @Guergeiro, i initially had the `optionals` config as:

```js
optionals: {
  request: {
    content_types: [ ... ]
  }
}
```

but it seemed weird and added more code to maintain, so i made it `read_body`. imo it seems to be "fluent" like... "ok, yes this config means to read the body or not" instead of like "ok these are request content types... because why? lemme look at the documentation again"