### PR TITLE
chore: Bump ResourceLoaderService to Deno Standard Modules 0.158.0

### DIFF
--- a/src/services/resource_loader/deps.ts
+++ b/src/services/resource_loader/deps.ts
@@ -1,2 +1,2 @@
-export { walkSync } from "https://deno.land/std@0.146.0/fs/mod.ts";
-export { join } from "https://deno.land/std@0.146.0/path/mod.ts";
+export { walkSync } from "https://deno.land/std@0.158.0/fs/mod.ts";
+export { join } from "https://deno.land/std@0.158.0/path/mod.ts";


### PR DESCRIPTION
Bump `ResourceLoaderService` to Deno Standard Modules 0.158.0