### PR TITLE
fix: sending a POST request without a body

### DIFF
--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -13,11 +13,11 @@ export type ParsedBody =
  */
 export class DrashRequest extends Request {
   public conn_info: ConnInfo;
-  readonly #path_params: Map<string, string>;
 
   #end_lifecycle = false;
   #original: Request;
   #parsed_body?: ParsedBody;
+  readonly #path_params: Map<string, string>;
   #search_params!: URLSearchParams;
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -13,9 +13,11 @@ export type ParsedBody =
  */
 export class DrashRequest extends Request {
   public conn_info: ConnInfo;
-  #end_lifecycle = false;
-  #parsed_body?: ParsedBody;
   readonly #path_params: Map<string, string>;
+
+  #end_lifecycle = false;
+  #original: Request;
+  #parsed_body?: ParsedBody;
   #search_params!: URLSearchParams;
 
   //////////////////////////////////////////////////////////////////////////////
@@ -39,9 +41,10 @@ export class DrashRequest extends Request {
     pathParams: Map<string, string>,
     connInfo: ConnInfo,
   ) {
-    super(originalRequest);
+    super(originalRequest.clone());
     this.#path_params = pathParams;
     this.conn_info = connInfo;
+    this.#original = originalRequest.clone();
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -53,7 +56,7 @@ export class DrashRequest extends Request {
   }
 
   get original(): Request {
-    return Object.getPrototypeOf(this);
+    return this.#original;
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/tests/integration/post_no_body_test.ts
+++ b/tests/integration/post_no_body_test.ts
@@ -29,12 +29,11 @@ const server = new Server({
 Deno.test("post_no_body_test.ts", async (t) => {
   await t.step("POST /post-no-body", async (t) => {
     /**
-     * This bug was discovered by sending no body ina post request.
+     * See the following for reasons why this test was added:
      *
-     * The fix was to remove the `#original_request` on `request.ts` as we cloned it,
-     * no body seemed to not be caught by the native code, but we didn't need it anyway.
+     *   - https://github.com/drashland/drash/pull/691
      */
-    await t.step("Does not throw if a body isnt defined", async () => {
+    await t.step("Does not throw if a body is not defined", async () => {
       server.run();
 
       const response = await TestHelpers.makeRequest.post(

--- a/tests/integration/server_with_optionals_request_test.ts
+++ b/tests/integration/server_with_optionals_request_test.ts
@@ -46,7 +46,7 @@ class HomeResource extends Drash.Resource {
 
 const createServer = (readBody: boolean) =>
   new Drash.Server({
-    hostname: "0.0.0.0",
+    hostname: "localhost",
     port: 1447,
     protocol: "http",
     resources: [

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -799,7 +799,6 @@ async function staticCreateTests(t: Deno.TestContext) {
       // null. See https://fetch.spec.whatwg.org/#dom-body-bodyused.
       assertEquals(request.bodyUsed, false);
       assertEquals(request.original.bodyUsed, false);
-
     },
   );
 }

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -628,6 +628,33 @@ async function originalRequestTests(t: Deno.TestContext) {
       assertEquals(json, { hello: "world" });
     },
   );
+
+  await t.step(
+    "original request can be retrieved and bodyUsed is false",
+    async () => {
+      // We expect this to be cloned in the `Drash.Request.create()` call
+      const serverRequest = new Request("https://drash.land", {
+        headers: { "x-hello": "goodbye", "x-goodbye": "hello" },
+        method: "POST",
+        redirect: "error",
+      });
+
+      // When creating a Drash.Request object, the body is automatically parsed
+      // and causes `Drash.Request.bodyUsed` to be `true`
+      const request = await Drash.Request.create(
+        serverRequest,
+        new Map(),
+        connInfo,
+      );
+
+      // Assert some equality between the two requests
+      assertEquals(request.original.bodyUsed, serverRequest.bodyUsed);
+      assertEquals(request.original.headers, serverRequest.headers);
+      assertEquals(request.original.method, serverRequest.method);
+      assertEquals(request.original.redirect, serverRequest.redirect);
+      assertEquals(request.original.url, serverRequest.url);
+    },
+  );
 }
 
 async function paramTests(t: Deno.TestContext) {


### PR DESCRIPTION
@ebebbington, this approach passes in a request clone to `super()` in `DrashRequest`'s constructor. most of the current code is left intact, the old tests are being used, and there are also tests i added in addition to the tests you added.

when i reviewed your PR, i noticed we couldn't get the `request.original` without the code throwing `Illegal invocation` which means we'd break current functionality because we allow users to access `request.original`. see screenshot below:

<img width="1215" alt="Screen Shot 2022-12-25 at 21 00 24" src="https://user-images.githubusercontent.com/12766301/209489967-efb57bfd-afd1-4fd8-9bee-440065e1a5eb.png">

i think the approach in this PR is the one we should go with. thoughts @ebebbington @Guergeiro? i could def be missing something here. this deno change seems like it had a big impact and we might just be hitting the surface with its effects.